### PR TITLE
feat(api): add rate limiting and throttling

### DIFF
--- a/src/hooks/useRateLimit.ts
+++ b/src/hooks/useRateLimit.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  getApiRateLimitStatus,
+  subscribeToApiRateLimit,
+  type ApiRateLimitStatus,
+} from "@/services/api";
+
+/**
+ * Exposes live API rate-limit status and keeps retry countdown in sync.
+ */
+export function useRateLimit() {
+  const [status, setStatus] = useState<ApiRateLimitStatus>(() => getApiRateLimitStatus());
+
+  useEffect(() => subscribeToApiRateLimit(setStatus), []);
+
+  useEffect(() => {
+    if (status.retryAfterMs <= 0) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      setStatus(getApiRateLimitStatus());
+    }, 1_000);
+
+    return () => clearInterval(interval);
+  }, [status.retryAfterMs]);
+
+  return status;
+}

--- a/src/hooks/useThrottle.ts
+++ b/src/hooks/useThrottle.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+
+/**
+ * Returns a throttled callback that runs at most once every delayMs window.
+ */
+export function useThrottle<T extends (...args: never[]) => void>(
+  callback: T,
+  delayMs: number,
+): T {
+  const lastCalledAtRef = useRef(0);
+
+  return useCallback(
+    ((...args: Parameters<T>) => {
+      const now = Date.now();
+      if (now - lastCalledAtRef.current < delayMs) {
+        return;
+      }
+
+      lastCalledAtRef.current = now;
+      callback(...args);
+    }) as T,
+    [callback, delayMs],
+  );
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,3 +1,6 @@
+import { RequestQueue } from "@/utils/requestQueue";
+import { RateLimiter } from "@/utils/rateLimiter";
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
 
 export interface CreatorProfile {
@@ -7,11 +10,96 @@ export interface CreatorProfile {
   preferredAsset: string;
 }
 
-/**
- * Shared fetch helper used by all API methods.
- * Centralizing this logic keeps retries, headers, and error handling consistent.
- */
-async function request<T>(path: string, init?: RequestInit): Promise<T> {
+export interface ApiRateLimitStatus {
+  isLimited: boolean;
+  retryAfterMs: number;
+  remainingRequests: number;
+  queuedRequests: number;
+  limit: number;
+  windowMs: number;
+}
+
+export class ApiRateLimitError extends Error {
+  readonly retryAfterMs: number;
+
+  constructor(retryAfterMs: number) {
+    const seconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+    super(`Rate limit reached. Try again in ${seconds}s.`);
+    this.name = "ApiRateLimitError";
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+const rateLimiter = new RateLimiter(10, 60_000);
+const requestQueue = new RequestQueue();
+const lastRequestByPath = new Map<string, number>();
+const statusSubscribers = new Set<(status: ApiRateLimitStatus) => void>();
+
+const DEFAULT_THROTTLE_MS = 300;
+
+interface RequestOptions {
+  /**
+   * Critical requests are rejected when limited.
+   * Non-critical requests are queued and retried with exponential backoff.
+   */
+  critical?: boolean;
+  throttleMs?: number;
+}
+
+const sleep = (delayMs: number) => new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+
+function getStatus(): ApiRateLimitStatus {
+  const state = rateLimiter.getState();
+  return {
+    isLimited: state.isLimited,
+    retryAfterMs: state.retryAfterMs,
+    remainingRequests: state.remainingRequests,
+    limit: state.limit,
+    windowMs: state.windowMs,
+    queuedRequests: requestQueue.size(),
+  };
+}
+
+function notifyStatusChange(): void {
+  const status = getStatus();
+  statusSubscribers.forEach((subscriber) => subscriber(status));
+}
+
+export function getApiRateLimitStatus(): ApiRateLimitStatus {
+  return getStatus();
+}
+
+export function subscribeToApiRateLimit(
+  callback: (status: ApiRateLimitStatus) => void,
+): () => void {
+  statusSubscribers.add(callback);
+  callback(getStatus());
+
+  return () => {
+    statusSubscribers.delete(callback);
+  };
+}
+
+async function applyPathThrottle(path: string, throttleMs = DEFAULT_THROTTLE_MS): Promise<void> {
+  const now = Date.now();
+  const lastRequestAt = lastRequestByPath.get(path);
+
+  if (lastRequestAt !== undefined) {
+    const elapsedMs = now - lastRequestAt;
+    if (elapsedMs < throttleMs) {
+      await sleep(throttleMs - elapsedMs);
+    }
+  }
+
+  lastRequestByPath.set(path, Date.now());
+}
+
+async function executeFetch<T>(path: string, init?: RequestInit, throttleMs?: number): Promise<T> {
+  await applyPathThrottle(path, throttleMs);
+
+  rateLimiter.recordRequest();
+  notifyStatusChange();
+
   const response = await fetch(`${API_BASE_URL}${path}`, {
     headers: {
       "Content-Type": "application/json",
@@ -29,9 +117,48 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   return (await response.json()) as T;
 }
 
+/**
+ * Shared fetch helper used by all API methods.
+ * Centralizing this logic keeps retries, headers, and error handling consistent.
+ */
+async function request<T>(path: string, init?: RequestInit, options?: RequestOptions): Promise<T> {
+  const critical = options?.critical ?? true;
+  const throttleMs = options?.throttleMs ?? DEFAULT_THROTTLE_MS;
+
+  if (!rateLimiter.canMakeRequest()) {
+    const retryAfterMs = rateLimiter.getRetryAfterMs();
+    notifyStatusChange();
+
+    if (critical) {
+      throw new ApiRateLimitError(retryAfterMs);
+    }
+
+    const queuedRequest = requestQueue.enqueue(
+      async () => {
+        if (!rateLimiter.canMakeRequest()) {
+          const waitMs = Math.max(100, rateLimiter.getRetryAfterMs());
+          await sleep(waitMs);
+        }
+
+        return executeFetch<T>(path, init, throttleMs);
+      },
+      { maxRetries: 4, baseDelayMs: 250 },
+    );
+
+    notifyStatusChange();
+    const result = await queuedRequest;
+    notifyStatusChange();
+    return result;
+  }
+
+  return executeFetch<T>(path, init, throttleMs);
+}
+
 export async function getCreatorProfile(username: string): Promise<CreatorProfile> {
   try {
-    return await request<CreatorProfile>(`/creators/${username}`);
+    return await request<CreatorProfile>(`/creators/${username}`, undefined, {
+      critical: false,
+    });
   } catch {
     // Fallback makes local UI work before backend endpoints are available.
     return {
@@ -48,8 +175,15 @@ export async function createTipIntent(payload: {
   amount: string;
   assetCode: string;
 }) {
-  return request<{ intentId: string; checkoutUrl?: string }>("/tips/intents", {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
+  return request<{ intentId: string; checkoutUrl?: string }>(
+    "/tips/intents",
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    },
+    {
+      critical: true,
+      throttleMs: 500,
+    },
+  );
 }

--- a/src/utils/rateLimiter.ts
+++ b/src/utils/rateLimiter.ts
@@ -1,0 +1,54 @@
+export interface RateLimiterState {
+  isLimited: boolean;
+  remainingRequests: number;
+  retryAfterMs: number;
+  limit: number;
+  windowMs: number;
+}
+
+export class RateLimiter {
+  private requests: number[] = [];
+
+  constructor(
+    private readonly limit = 10,
+    private readonly windowMs = 60_000,
+  ) {}
+
+  canMakeRequest(now = Date.now()): boolean {
+    this.prune(now);
+    return this.requests.length < this.limit;
+  }
+
+  recordRequest(now = Date.now()): void {
+    this.prune(now);
+    this.requests.push(now);
+  }
+
+  getRetryAfterMs(now = Date.now()): number {
+    this.prune(now);
+    if (this.requests.length < this.limit) {
+      return 0;
+    }
+
+    const oldestRequest = this.requests[0];
+    return Math.max(0, this.windowMs - (now - oldestRequest));
+  }
+
+  getState(now = Date.now()): RateLimiterState {
+    this.prune(now);
+    const retryAfterMs = this.getRetryAfterMs(now);
+    const remainingRequests = Math.max(0, this.limit - this.requests.length);
+
+    return {
+      isLimited: retryAfterMs > 0,
+      remainingRequests,
+      retryAfterMs,
+      limit: this.limit,
+      windowMs: this.windowMs,
+    };
+  }
+
+  private prune(now: number): void {
+    this.requests = this.requests.filter((timestamp) => now - timestamp < this.windowMs);
+  }
+}

--- a/src/utils/requestQueue.ts
+++ b/src/utils/requestQueue.ts
@@ -1,0 +1,80 @@
+const sleep = (delayMs: number) => new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+
+export interface RequestQueueOptions {
+  maxRetries?: number;
+  baseDelayMs?: number;
+}
+
+interface QueueTask<T> {
+  task: () => Promise<T>;
+  maxRetries: number;
+  baseDelayMs: number;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+}
+
+export class RequestQueue {
+  private queue: Array<QueueTask<unknown>> = [];
+
+  private processing = false;
+
+  enqueue<T>(task: () => Promise<T>, options?: RequestQueueOptions): Promise<T> {
+    const maxRetries = options?.maxRetries ?? 3;
+    const baseDelayMs = options?.baseDelayMs ?? 250;
+
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push({
+        task,
+        maxRetries,
+        baseDelayMs,
+        resolve,
+        reject,
+      });
+
+      if (!this.processing) {
+        void this.processNext();
+      }
+    });
+  }
+
+  size(): number {
+    return this.queue.length;
+  }
+
+  private async processNext(): Promise<void> {
+    this.processing = true;
+
+    while (this.queue.length > 0) {
+      const queueTask = this.queue.shift() as QueueTask<unknown>;
+
+      try {
+        const result = await this.runWithRetries(queueTask);
+        queueTask.resolve(result);
+      } catch (error) {
+        queueTask.reject(error);
+      }
+    }
+
+    this.processing = false;
+  }
+
+  private async runWithRetries<T>(queueTask: QueueTask<T>): Promise<T> {
+    let attempt = 0;
+
+    while (attempt <= queueTask.maxRetries) {
+      try {
+        return await queueTask.task();
+      } catch (error) {
+        if (attempt === queueTask.maxRetries) {
+          throw error;
+        }
+
+        const delayMs = queueTask.baseDelayMs * 2 ** attempt;
+        await sleep(delayMs);
+        attempt += 1;
+      }
+    }
+
+    throw new Error("Request queue unexpectedly exceeded retry loop.");
+  }
+}


### PR DESCRIPTION
## Summary
- Add a client-side rate limiter with a 10 requests/minute window and retry countdown support.
- Add endpoint throttling, queue non-critical requests when limited, and apply exponential backoff retries.
- Add reusable hooks to expose rate-limit state and throttle rapid UI-triggered callbacks.

## Test plan
- [ ] Run `npm install`
- [ ] Run `npm run typecheck`
- [ ] Run `npm run lint`
- [ ] Trigger rapid API calls and verify throttling behavior
- [ ] Exceed 10 requests/minute and verify countdown/error feedback
- [ ] Verify non-critical requests queue and recover after the window resets

closes #21 