### PR TITLE
feat(forms): add validation with React Hook Form and Zod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,14 @@
       "name": "stellar-tipjar-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
         "@stellar/freighter-api": "^6.0.1",
         "@stellar/stellar-sdk": "^14.6.1",
         "next": "latest",
         "react": "latest",
-        "react-dom": "latest"
+        "react-dom": "latest",
+        "react-hook-form": "^7.72.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -444,6 +447,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1251,6 +1266,12 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@stellar/freighter-api": {
@@ -5629,6 +5650,22 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.0.tgz",
+      "integrity": "sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6938,7 +6975,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -14,11 +14,14 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^14.6.1",
     "next": "latest",
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "react-hook-form": "^7.72.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/creator/[username]/page.tsx
+++ b/src/app/creator/[username]/page.tsx
@@ -1,6 +1,9 @@
 import Link from "next/link";
+import { notFound } from "next/navigation";
 
 import { Button } from "@/components/Button";
+import { TipForm } from "@/components/forms/TipForm";
+import { creatorUsernameSchema } from "@/schemas/creatorSchema";
 import { getCreatorProfile } from "@/services/api";
 import { formatUsername } from "@/utils/format";
 
@@ -11,7 +14,12 @@ interface CreatorPageProps {
 }
 
 export default async function CreatorPage({ params }: CreatorPageProps) {
-  const profile = await getCreatorProfile(params.username);
+  const parsedUsername = creatorUsernameSchema.safeParse(params.username);
+  if (!parsedUsername.success) {
+    notFound();
+  }
+
+  const profile = await getCreatorProfile(parsedUsername.data);
 
   return (
     <section className="space-y-8">
@@ -31,6 +39,14 @@ export default async function CreatorPage({ params }: CreatorPageProps) {
           <Link href="/explore">
             <Button variant="ghost">Back to Explore</Button>
           </Link>
+        </div>
+
+        <div className="mt-8 rounded-2xl border border-ink/10 bg-white/70 p-5 sm:p-6">
+          <h2 className="text-xl font-semibold text-ink">Send a Tip</h2>
+          <p className="mt-2 text-sm text-ink/70">
+            Amount and asset values are validated on blur and submit before calling the API.
+          </p>
+          <TipForm username={profile.username} defaultAssetCode={profile.preferredAsset} />
         </div>
       </div>
     </section>

--- a/src/components/forms/FormError.tsx
+++ b/src/components/forms/FormError.tsx
@@ -1,0 +1,16 @@
+interface FormErrorProps {
+  id: string;
+  message?: string;
+}
+
+export function FormError({ id, message }: FormErrorProps) {
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <p id={id} role="status" aria-live="polite" className="mt-1 text-xs text-error">
+      {message}
+    </p>
+  );
+}

--- a/src/components/forms/FormInput.tsx
+++ b/src/components/forms/FormInput.tsx
@@ -1,0 +1,32 @@
+import { type InputHTMLAttributes } from "react";
+import { type UseFormRegisterReturn } from "react-hook-form";
+
+import { FormError } from "@/components/forms/FormError";
+
+interface FormInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "name"> {
+  label: string;
+  error?: string;
+  registration: UseFormRegisterReturn;
+}
+
+export function FormInput({ label, error, registration, className = "", id, ...props }: FormInputProps) {
+  const inputId = id ?? registration.name;
+  const errorId = `${inputId}-error`;
+
+  return (
+    <label className="block text-sm font-medium text-ink" htmlFor={inputId}>
+      <span>{label}</span>
+      <input
+        id={inputId}
+        aria-invalid={Boolean(error)}
+        aria-describedby={error ? errorId : undefined}
+        className={`mt-1 w-full rounded-xl border bg-white px-3 py-2 text-sm text-ink placeholder:text-ink/40 focus:outline-none focus:ring-2 ${
+          error ? "border-error/60 focus:ring-error/30" : "border-ink/20 focus:ring-wave/30"
+        } ${className}`}
+        {...registration}
+        {...props}
+      />
+      <FormError id={errorId} message={error} />
+    </label>
+  );
+}

--- a/src/components/forms/TipForm.tsx
+++ b/src/components/forms/TipForm.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+
+import { Button } from "@/components/Button";
+import { FormError } from "@/components/forms/FormError";
+import { FormInput } from "@/components/forms/FormInput";
+import { createTipIntent } from "@/services/api";
+import { tipSchema, type TipSchemaInput, type TipSchemaValues } from "@/schemas/tipSchema";
+
+interface TipFormProps {
+  username: string;
+  defaultAssetCode?: string;
+}
+
+export function TipForm({ username, defaultAssetCode = "XLM" }: TipFormProps) {
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitSuccess, setSubmitSuccess] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<TipSchemaInput>({
+    resolver: zodResolver(tipSchema),
+    mode: "onBlur",
+    reValidateMode: "onChange",
+    defaultValues: {
+      amount: 1,
+      message: "",
+      assetCode: defaultAssetCode,
+    },
+  });
+
+  const onSubmit = async (values: TipSchemaInput) => {
+    setSubmitError(null);
+    setSubmitSuccess(null);
+
+    const parsed: TipSchemaValues = tipSchema.parse(values);
+
+    try {
+      const intent = await createTipIntent({
+        username,
+        amount: parsed.amount.toString(),
+        assetCode: parsed.assetCode,
+      });
+
+      setSubmitSuccess(
+        intent.checkoutUrl
+          ? `Tip intent created. Continue at: ${intent.checkoutUrl}`
+          : `Tip intent created successfully. Intent ID: ${intent.intentId}`,
+      );
+      reset({
+        amount: 1,
+        message: "",
+        assetCode: parsed.assetCode,
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Something went wrong while creating the tip intent.";
+      setSubmitError(message);
+    }
+  };
+
+  return (
+    <form className="mt-6 space-y-4" onSubmit={handleSubmit(onSubmit)} noValidate>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <FormInput
+          label="Amount"
+          type="number"
+          min="0.01"
+          step="0.01"
+          inputMode="decimal"
+          placeholder="10.00"
+          registration={register("amount", { valueAsNumber: true })}
+          error={errors.amount?.message}
+        />
+        <FormInput
+          label="Asset Code"
+          type="text"
+          maxLength={12}
+          placeholder="XLM"
+          registration={register("assetCode")}
+          error={errors.assetCode?.message}
+        />
+      </div>
+
+      <label className="block text-sm font-medium text-ink">
+        <span>Message (optional)</span>
+        <textarea
+          className={`mt-1 min-h-24 w-full rounded-xl border bg-white px-3 py-2 text-sm text-ink placeholder:text-ink/40 focus:outline-none focus:ring-2 ${
+            errors.message ? "border-error/60 focus:ring-error/30" : "border-ink/20 focus:ring-wave/30"
+          }`}
+          placeholder="Leave a supportive message"
+          aria-invalid={Boolean(errors.message)}
+          aria-describedby={errors.message ? "tip-message-error" : undefined}
+          {...register("message")}
+        />
+        <FormError id="tip-message-error" message={errors.message?.message} />
+      </label>
+
+      {submitError ? (
+        <p role="alert" aria-live="assertive" className="rounded-lg border border-error/30 bg-error/5 px-3 py-2 text-sm text-error">
+          {submitError}
+        </p>
+      ) : null}
+
+      {submitSuccess ? (
+        <p role="status" aria-live="polite" className="rounded-lg border border-success/30 bg-success/5 px-3 py-2 text-sm text-success">
+          {submitSuccess}
+        </p>
+      ) : null}
+
+      <div className="flex flex-wrap gap-3">
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? "Creating Intent..." : "Create Tip Intent"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -43,7 +43,10 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     const watcher = new WatchWalletChanges();
     watcher.watch((data) => {
       // In @stellar/freighter-api 6.0, data contains { address, network, ... }
-      const newAddress = (data as any).address;
+      const newAddress =
+        typeof data === "object" && data !== null && "address" in data
+          ? (data as { address?: string }).address
+          : undefined;
       if (newAddress && newAddress !== publicKey) {
         setPublicKey(newAddress);
       } else if (!newAddress && publicKey) {
@@ -81,10 +84,10 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       if (pk) {
         setPublicKey(pk);
       }
-    } catch (err: any) {
-      if (err.message === "FREIGHTER_NOT_INSTALLED") {
+    } catch (err: unknown) {
+      if (err instanceof Error && err.message === "FREIGHTER_NOT_INSTALLED") {
         setError("Freighter wallet extension is not installed.");
-      } else if (err.message === "USER_DECLINED") {
+      } else if (err instanceof Error && err.message === "USER_DECLINED") {
         setError("You declined the connection request.");
       } else {
         setError("Failed to connect Freighter.");

--- a/src/hooks/useThrottle.ts
+++ b/src/hooks/useThrottle.ts
@@ -11,8 +11,8 @@ export function useThrottle<T extends (...args: never[]) => void>(
 ): T {
   const lastCalledAtRef = useRef(0);
 
-  return useCallback(
-    ((...args: Parameters<T>) => {
+  const throttled = useCallback(
+    (...args: Parameters<T>) => {
       const now = Date.now();
       if (now - lastCalledAtRef.current < delayMs) {
         return;
@@ -20,7 +20,9 @@ export function useThrottle<T extends (...args: never[]) => void>(
 
       lastCalledAtRef.current = now;
       callback(...args);
-    }) as T,
+    },
     [callback, delayMs],
   );
+
+  return throttled as T;
 }

--- a/src/schemas/creatorSchema.ts
+++ b/src/schemas/creatorSchema.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const creatorUsernameSchema = z
+  .string()
+  .trim()
+  .min(2, "Username must be at least 2 characters.")
+  .max(32, "Username must be 32 characters or fewer.")
+  .regex(
+    /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/,
+    "Username can include letters, numbers, underscores, and hyphens only.",
+  );
+
+export const creatorSchema = z.object({
+  username: creatorUsernameSchema,
+});
+
+export type CreatorSchemaValues = z.infer<typeof creatorSchema>;

--- a/src/schemas/tipSchema.ts
+++ b/src/schemas/tipSchema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const tipSchema = z.object({
+  amount: z.coerce
+    .number()
+    .refine((value) => Number.isFinite(value), "Enter a valid amount.")
+    .positive("Amount must be greater than 0.")
+    .min(0.01, "Minimum tip amount is 0.01 XLM."),
+  message: z
+    .string()
+    .max(500, "Message must be 500 characters or fewer.")
+    .optional()
+    .or(z.literal("")),
+  assetCode: z
+    .string()
+    .trim()
+    .min(1, "Asset code is required.")
+    .max(12, "Asset code must be 12 characters or fewer.")
+    .regex(/^[A-Za-z0-9]+$/, "Asset code can only contain letters and numbers.")
+    .transform((value) => value.toUpperCase()),
+});
+
+export type TipSchemaInput = z.input<typeof tipSchema>;
+export type TipSchemaValues = z.output<typeof tipSchema>;

--- a/src/services/walletService.ts
+++ b/src/services/walletService.ts
@@ -11,11 +11,29 @@ export interface WalletInfo {
   network: string;
 }
 
+function readBooleanProp(value: unknown, key: string): boolean {
+  if (typeof value === "object" && value !== null && key in value) {
+    const propValue = (value as Record<string, unknown>)[key];
+    return propValue === true;
+  }
+
+  return value === true;
+}
+
+function readStringProp(value: unknown, key: string): string | null {
+  if (typeof value === "object" && value !== null && key in value) {
+    const propValue = (value as Record<string, unknown>)[key];
+    return typeof propValue === "string" ? propValue : null;
+  }
+
+  return null;
+}
+
 export const walletService = {
   isAvailable: async () => {
     try {
-      const result = await isConnected() as any;
-      return !!(result === true || result?.isConnected);
+      const result = await isConnected();
+      return readBooleanProp(result, "isConnected");
     } catch (e) {
       console.warn("Freighter connection check failed", e);
       return false;
@@ -24,8 +42,8 @@ export const walletService = {
 
   isAllowed: async () => {
     try {
-      const result = await isAllowed() as any;
-      return !!(result === true || result?.isAllowed);
+      const result = await isAllowed();
+      return readBooleanProp(result, "isAllowed");
     } catch (e) {
       console.warn("Freighter permission check failed", e);
       return false;
@@ -34,37 +52,42 @@ export const walletService = {
 
   connect: async (): Promise<string | null> => {
     try {
-      const connection = await isConnected() as any;
-      const isConnectedBool = !!(connection === true || connection?.isConnected);
+      const connection = await isConnected();
+      const isConnectedBool = readBooleanProp(connection, "isConnected");
       if (!isConnectedBool) {
         throw new Error("FREIGHTER_NOT_INSTALLED");
       }
 
       // Check if already allowed, if not setAllowed
-      const allowed = await isAllowed() as any;
-      const isAllowedBool = !!(allowed === true || allowed?.isAllowed);
+      const allowed = await isAllowed();
+      const isAllowedBool = readBooleanProp(allowed, "isAllowed");
       if (!isAllowedBool) {
-        const setAllowedResult = await setAllowed() as any;
-        const isSetAllowedBool = !!(setAllowedResult === true || setAllowedResult?.isAllowed);
+        const setAllowedResult = await setAllowed();
+        const isSetAllowedBool = readBooleanProp(setAllowedResult, "isAllowed");
         if (!isSetAllowedBool) {
-           throw new Error("USER_DECLINED");
+          throw new Error("USER_DECLINED");
         }
       }
 
-      const result = await getAddress() as any;
+      const result = await getAddress();
       if (typeof result === "string") {
         return result;
       }
-      if (result?.address) {
-        return result.address;
+      const address = readStringProp(result, "address");
+      if (address) {
+        return address;
       }
-      if (result?.error) {
-        throw new Error(result.error);
+      const errorMessage = readStringProp(result, "error");
+      if (errorMessage) {
+        throw new Error(errorMessage);
       }
       return null;
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to connect wallet:", error);
-      if (error.message === "User declined access" || error.message === "USER_DECLINED") {
+      if (
+        error instanceof Error &&
+        (error.message === "User declined access" || error.message === "USER_DECLINED")
+      ) {
         throw new Error("USER_DECLINED");
       }
       throw error;
@@ -74,16 +97,18 @@ export const walletService = {
   sign: async (xdr: string, network: string) => {
     try {
       const result = await signTransaction(xdr, {
-        network,
-      }) as any;
+        networkPassphrase: network,
+      });
       if (typeof result === "string") {
         return result;
       }
-      if (result?.signedTxXdr) {
-        return result.signedTxXdr;
+      const signedTxXdr = readStringProp(result, "signedTxXdr");
+      if (signedTxXdr) {
+        return signedTxXdr;
       }
-      if (result?.error) {
-        throw new Error(result.error);
+      const errorMessage = readStringProp(result, "error");
+      if (errorMessage) {
+        throw new Error(errorMessage);
       }
       throw new Error("Signing failed");
     } catch (error) {

--- a/src/utils/requestQueue.ts
+++ b/src/utils/requestQueue.ts
@@ -9,7 +9,7 @@ interface QueueTask<T> {
   task: () => Promise<T>;
   maxRetries: number;
   baseDelayMs: number;
-  resolve: (value: T) => void;
+  resolve: (value: unknown) => void;
   reject: (error: unknown) => void;
 }
 
@@ -24,10 +24,10 @@ export class RequestQueue {
 
     return new Promise<T>((resolve, reject) => {
       this.queue.push({
-        task,
+        task: task as () => Promise<unknown>,
         maxRetries,
         baseDelayMs,
-        resolve,
+        resolve: resolve as (value: unknown) => void,
         reject,
       });
 


### PR DESCRIPTION
## Summary
- Add React Hook Form + Zod based validation dependencies and typed validation schemas for creators and tips.
- Add reusable validated form building blocks (`FormInput`, `FormError`) and a new client-side `TipForm` with clear accessible error/success messaging.
- Integrate validated tip creation directly into the creator profile page and validate route username format with schema checks.
- Resolve strict typing/lint issues in wallet/throttle/request queue helpers surfaced during typecheck/lint validation.

## Test plan
- [x] Run `npm run typecheck`
- [x] Run `npm run lint`
- [ ] Open a creator page and verify blur/submit validation messages
- [ ] Try invalid values (negative amount, zero amount, bad asset code) and confirm submission is blocked
- [ ] Submit valid values and confirm tip intent success feedback appears

closes #3 