### PR TITLE
feat: add creator QR code spec (requirements, design, tasks)

### DIFF
--- a/.kiro/specs/creator-qr-code/.config.kiro
+++ b/.kiro/specs/creator-qr-code/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "17d73d9d-4bd0-4563-8953-64d2fc786fad", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/creator-qr-code/design.md
+++ b/.kiro/specs/creator-qr-code/design.md
@@ -1,0 +1,217 @@
+# Design Document: Creator QR Code
+
+## Overview
+
+This feature adds a QR code panel to creator profile pages. The QR code encodes the creator's
+canonical profile URL so visitors can scan it to open the profile on another device or share it
+offline. The panel also exposes size controls (128 / 256 / 512 px) and a one-click PNG download.
+
+All QR rendering happens entirely in the browser via a lightweight client-side component so that
+server-side rendering of the profile page is never blocked.
+
+### Technology Choice
+
+QR generation is handled by **`qrcode`** (npm: `qrcode`), a well-maintained, zero-dependency
+library that runs in both Node and the browser. It exposes a `toDataURL` API that returns a
+base64-encoded PNG — exactly what we need for both `<img>` rendering and the download flow.
+No canvas manipulation or third-party service is required.
+
+---
+
+## Architecture
+
+```mermaid
+graph TD
+    A[CreatorPage (Server Component)] -->|renders| B[QRCodePanel (Client Component)]
+    B -->|calls| C[qrcode.toDataURL]
+    C -->|returns base64 PNG| B
+    B -->|renders| D[<img> element]
+    B -->|on download click| E[Download Handler]
+    E -->|creates <a> with href=dataURL| F[Browser file download]
+```
+
+The `CreatorPage` server component passes `username` and `displayName` as props to `QRCodePanel`.
+`QRCodePanel` is a `"use client"` component that owns all QR state (selected size, data URL,
+loading/error). The server component is never re-rendered by QR interactions.
+
+---
+
+## Components and Interfaces
+
+### `QRCodePanel` — `src/components/QRCodePanel.tsx`
+
+```ts
+interface QRCodePanelProps {
+  username: string;       // raw username, e.g. "alice"
+  displayName: string;    // creator's display name
+  profileUrl: string;     // absolute URL, e.g. "https://example.com/creator/alice"
+}
+```
+
+Internal state:
+
+| State field  | Type                        | Default  |
+|--------------|-----------------------------|----------|
+| `size`       | `128 \| 256 \| 512`         | `256`    |
+| `dataUrl`    | `string \| null`            | `null`   |
+| `isLoading`  | `boolean`                   | `true`   |
+| `error`      | `string \| null`            | `null`   |
+
+Lifecycle:
+- On mount and whenever `size` or `profileUrl` changes, call `qrcode.toDataURL(profileUrl, { width: size, margin: 2 })`.
+- Set `isLoading = true` before the call, `isLoading = false` after.
+- On success store the result in `dataUrl`; on failure store a message in `error`.
+
+### Size selector
+
+Three `<button>` elements labelled "S", "M", "L" (128 / 256 / 512). The active size gets a
+`ring-2 ring-wave` highlight. Clicking a button updates `size` state.
+
+### Download handler
+
+```ts
+function handleDownload(dataUrl: string, username: string): void {
+  const link = document.createElement("a");
+  link.href = dataUrl;
+  link.download = `qr-${username}.png`;
+  if (link.download !== undefined) {
+    link.click();
+  } else {
+    window.open(dataUrl, "_blank");
+  }
+}
+```
+
+The `link.download !== undefined` guard covers the fallback for browsers that do not support the
+`download` attribute (Requirement 3.4).
+
+### Integration into `CreatorPage`
+
+`CreatorPage` constructs the absolute profile URL using the `NEXT_PUBLIC_SITE_URL` environment
+variable (falling back to `""` so the component can show an error gracefully):
+
+```ts
+const profileUrl = process.env.NEXT_PUBLIC_SITE_URL
+  ? `${process.env.NEXT_PUBLIC_SITE_URL}/creator/${profile.username}`
+  : "";
+```
+
+`QRCodePanel` is rendered inside the existing profile card `<div>`, below the action buttons and
+above the tip form section.
+
+---
+
+## Data Models
+
+No new server-side data models are required. All state is ephemeral and lives inside
+`QRCodePanel`.
+
+### Size type
+
+```ts
+type QRSize = 128 | 256 | 512;
+
+const SIZE_LABELS: Record<QRSize, string> = {
+  128: "S",
+  256: "M",
+  512: "L",
+};
+```
+
+### Environment variable
+
+| Variable                | Required | Purpose                                      |
+|-------------------------|----------|----------------------------------------------|
+| `NEXT_PUBLIC_SITE_URL`  | No       | Base URL used to build the Creator_Profile_URL. Falls back to empty string, which causes `QRCodePanel` to display an error. |
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a
+system — essentially, a formal statement about what the system should do. Properties serve as the
+bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: QR data encodes the full absolute profile URL
+
+*For any* valid username and site URL, the data URL produced by `qrcode.toDataURL` must decode
+back to the exact `${siteUrl}/creator/${username}` string — full scheme, host, and path with no
+truncation or relative path.
+
+**Validates: Requirements 1.1, 1.2, 1.3**
+
+---
+
+### Property 2: Size selection produces correct square pixel dimensions
+
+*For any* selected `QRSize` value (128, 256, or 512), the PNG image encoded in the resulting data
+URL must have width equal to that size and height equal to that size (1:1 aspect ratio enforced).
+
+**Validates: Requirements 2.1, 2.2, 2.4**
+
+---
+
+### Property 3: Download filename matches username
+
+*For any* username string, `handleDownload` must set the `<a>` element's `download` attribute to
+exactly `qr-${username}.png`.
+
+**Validates: Requirements 3.2**
+
+---
+
+### Property 4: Empty or invalid profile URL triggers error state
+
+*For any* `QRCodePanel` rendered with an empty or otherwise invalid `profileUrl`, the component
+must set `error` to a non-null string and must not render the QR `<img>` element.
+
+**Validates: Requirements 1.4**
+
+---
+
+### Property 5: Creator info is always displayed alongside the QR code
+
+*For any* `displayName` and `username` passed to `QRCodePanel`, the rendered output must contain
+the display name text and the `@`-prefixed username text adjacent to the QR code area.
+
+**Validates: Requirements 4.1, 4.2**
+
+---
+
+## Error Handling
+
+| Scenario | Behaviour |
+|---|---|
+| `NEXT_PUBLIC_SITE_URL` not set | `profileUrl` is `""`. `qrcode.toDataURL("")` rejects; component shows inline error message. |
+| `qrcode.toDataURL` rejects for any reason | `error` state is set; `<img>` is replaced by an error message paragraph. |
+| Browser lacks `download` attribute support | `handleDownload` falls back to `window.open(dataUrl, "_blank")`. |
+| Profile data unavailable (API error) | Handled upstream by `CreatorPage`; `QRCodePanel` is not rendered. |
+
+---
+
+## Testing Strategy
+
+### Unit tests (Vitest + React Testing Library)
+
+- Render `QRCodePanel` with a valid `profileUrl` and assert the `<img>` appears after async generation.
+- Assert the default selected size button is "M" on first render (Requirement 2.3).
+- Click the download button and assert an `<a>` with the correct `download` attribute is triggered (Requirement 3.1, 3.3).
+- Stub an anchor without `download` support and assert `window.open` is called as fallback (Requirement 3.4).
+- Assert a loading indicator is shown while QR generation is in progress (Requirement 4.3).
+- Assert `QRCodePanel` is rendered inside the profile card section of `CreatorPage` (Requirement 5.1).
+
+### Property-based tests (fast-check)
+
+Each property test runs a minimum of **100 iterations**.
+Each test is tagged with a comment in the format:
+`// Feature: creator-qr-code, Property <N>: <property_text>`
+
+| Property | Test description |
+|---|---|
+| P1 — QR encodes full absolute URL | For any `(username, siteUrl)` pair, call `qrcode.toDataURL` and decode the resulting PNG; assert the embedded string equals `${siteUrl}/creator/${username}`. |
+| P2 — Size matches selection | For any `QRSize` in `{128, 256, 512}`, generate a QR and parse the PNG IHDR chunk to assert width === height === size. |
+| P3 — Download filename matches username | For any username string, call `handleDownload` with a stub anchor and assert `anchor.download === \`qr-${username}.png\``. |
+| P4 — Empty URL → error state | For any empty or blank `profileUrl`, render `QRCodePanel` and assert `error` text is visible and no `<img>` is present. |
+| P5 — Creator info displayed | For any `(displayName, username)` pair, render `QRCodePanel` and assert both the display name and `@username` appear in the output. |
+
+**Library**: `fast-check` (install as dev dependency alongside `vitest`).

--- a/.kiro/specs/creator-qr-code/requirements.md
+++ b/.kiro/specs/creator-qr-code/requirements.md
@@ -1,0 +1,82 @@
+# Requirements Document
+
+## Introduction
+
+This feature adds QR code generation to creator profile pages in the Stellar Tip Jar frontend.
+Each creator gets a QR code that encodes their profile URL, enabling visitors to scan and share
+the profile on mobile devices or initiate tipping flows quickly. QR codes are rendered in the
+browser, support configurable sizes, and can be downloaded as PNG images.
+
+## Glossary
+
+- **QR_Generator**: The client-side component responsible for generating and rendering QR code images from a creator profile URL.
+- **Creator_Profile_URL**: The canonical URL of a creator's profile page, e.g. `https://<host>/creator/<username>`.
+- **QR_Code_Image**: The visual QR code artifact rendered on screen and available for download.
+- **Download_Handler**: The browser-side logic that converts the rendered QR code into a downloadable PNG file.
+- **Size_Option**: A discrete pixel dimension (small: 128px, medium: 256px, large: 512px) the user may select for the QR code.
+- **Creator_Profile_Page**: The Next.js page at `src/app/creator/[username]/page.tsx` that displays creator information and tipping UI.
+
+---
+
+## Requirements
+
+### Requirement 1: QR Code Generation
+
+**User Story:** As a visitor, I want to see a QR code on a creator's profile page, so that I can scan it with my phone to quickly open the profile or start a tip.
+
+#### Acceptance Criteria
+
+1. WHEN a creator profile page loads, THE QR_Generator SHALL render a QR_Code_Image encoding the Creator_Profile_URL for that creator.
+2. THE QR_Generator SHALL embed the full absolute Creator_Profile_URL (scheme + host + path) in the QR code data.
+3. WHEN the Creator_Profile_URL is scanned, THE resulting navigation SHALL open the correct creator profile page.
+4. IF the Creator_Profile_URL cannot be determined, THEN THE QR_Generator SHALL display an error message in place of the QR_Code_Image.
+
+---
+
+### Requirement 2: Configurable QR Code Size
+
+**User Story:** As a visitor, I want to choose the size of the QR code, so that I can get a version suitable for sharing or printing.
+
+#### Acceptance Criteria
+
+1. THE QR_Generator SHALL support three Size_Options: 128px (small), 256px (medium), and 512px (large).
+2. WHEN a user selects a Size_Option, THE QR_Generator SHALL re-render the QR_Code_Image at the selected pixel dimension within 300ms.
+3. THE QR_Generator SHALL default to the medium (256px) Size_Option on initial render.
+4. THE QR_Code_Image SHALL maintain a 1:1 aspect ratio at all Size_Options.
+
+---
+
+### Requirement 3: QR Code Download
+
+**User Story:** As a visitor, I want to download the QR code as an image file, so that I can share it offline or embed it in other materials.
+
+#### Acceptance Criteria
+
+1. WHEN a user activates the download control, THE Download_Handler SHALL initiate a browser file download of the QR_Code_Image as a PNG file.
+2. THE Download_Handler SHALL name the downloaded file `qr-<username>.png` where `<username>` is the creator's username.
+3. THE Download_Handler SHALL export the QR_Code_Image at the currently selected Size_Option resolution.
+4. IF the browser does not support the download API, THEN THE Download_Handler SHALL open the QR_Code_Image in a new browser tab as a fallback.
+
+---
+
+### Requirement 4: Creator Info Overlay
+
+**User Story:** As a visitor, I want the QR code display to show the creator's name alongside the code, so that I know whose profile the QR code belongs to.
+
+#### Acceptance Criteria
+
+1. THE QR_Generator SHALL display the creator's display name adjacent to the QR_Code_Image.
+2. THE QR_Generator SHALL display the creator's username (formatted with `@` prefix) adjacent to the QR_Code_Image.
+3. WHILE the QR_Code_Image is rendering, THE QR_Generator SHALL display a loading indicator in place of the QR_Code_Image.
+
+---
+
+### Requirement 5: Integration with Creator Profile Page
+
+**User Story:** As a visitor, I want the QR code to appear naturally within the creator profile page, so that it is easy to find without disrupting the existing layout.
+
+#### Acceptance Criteria
+
+1. THE Creator_Profile_Page SHALL render the QR_Generator component within the existing profile card section.
+2. THE QR_Generator SHALL be a client-side component and SHALL NOT block server-side rendering of the Creator_Profile_Page.
+3. WHERE the application is accessed on a mobile viewport (width < 640px), THE QR_Generator SHALL stack its controls vertically to remain usable.

--- a/.kiro/specs/creator-qr-code/tasks.md
+++ b/.kiro/specs/creator-qr-code/tasks.md
@@ -1,0 +1,112 @@
+# Implementation Plan: Creator QR Code
+
+## Overview
+
+Add a `QRCodePanel` client component to creator profile pages that generates a QR code encoding
+the creator's canonical profile URL, supports three size options, and enables PNG download.
+
+## Tasks
+
+- [ ] 1. Install dependencies and define shared types
+  - Install `qrcode` and `@types/qrcode` as dependencies
+  - Install `fast-check` as a dev dependency (for property tests)
+  - Create `src/components/QRCodePanel.tsx` with the `QRSize` type, `SIZE_LABELS` constant, and `QRCodePanelProps` interface
+  - _Requirements: 2.1, 2.3_
+
+- [ ] 2. Implement the `handleDownload` utility and its tests
+  - [ ] 2.1 Implement `handleDownload(dataUrl, username)` inside `QRCodePanel.tsx`
+    - Create an `<a>` element, set `href` and `download`, click if supported, else `window.open` fallback
+    - _Requirements: 3.1, 3.2, 3.3, 3.4_
+
+  - [ ]* 2.2 Write property test for download filename (Property 3)
+    - **Property 3: Download filename matches username**
+    - **Validates: Requirements 3.2**
+    - For any username string, stub an anchor and assert `anchor.download === \`qr-${username}.png\``
+
+  - [ ]* 2.3 Write unit tests for `handleDownload`
+    - Test normal download path (anchor click triggered)
+    - Test fallback path when `download` attribute is unsupported (`window.open` called)
+    - _Requirements: 3.1, 3.4_
+
+- [ ] 3. Implement `QRCodePanel` component
+  - [ ] 3.1 Implement core QR generation logic
+    - Add `"use client"` directive
+    - Declare state: `size`, `dataUrl`, `isLoading`, `error`
+    - In a `useEffect` keyed on `[profileUrl, size]`, call `qrcode.toDataURL(profileUrl, { width: size, margin: 2 })`
+    - Set `isLoading = true` before the call; on success set `dataUrl`; on failure set `error`
+    - If `profileUrl` is empty, set `error` immediately without calling the library
+    - _Requirements: 1.1, 1.2, 1.4, 2.2_
+
+  - [ ]* 3.2 Write property test for QR data encoding (Property 1)
+    - **Property 1: QR data encodes the full absolute profile URL**
+    - **Validates: Requirements 1.1, 1.2, 1.3**
+    - For any `(username, siteUrl)` pair, call `qrcode.toDataURL` and decode the PNG; assert embedded string equals `${siteUrl}/creator/${username}`
+
+  - [ ]* 3.3 Write property test for empty URL error state (Property 4)
+    - **Property 4: Empty or invalid profile URL triggers error state**
+    - **Validates: Requirements 1.4**
+    - For any empty or blank `profileUrl`, render `QRCodePanel` and assert error text is visible and no `<img>` is present
+
+  - [ ] 3.4 Implement size selector UI
+    - Render three `<button>` elements labelled "S", "M", "L" for sizes 128, 256, 512
+    - Default selected size is 256 (medium)
+    - Active size gets a `ring-2 ring-wave` highlight
+    - _Requirements: 2.1, 2.2, 2.3, 2.4_
+
+  - [ ]* 3.5 Write property test for size pixel dimensions (Property 2)
+    - **Property 2: Size selection produces correct square pixel dimensions**
+    - **Validates: Requirements 2.1, 2.2, 2.4**
+    - For any `QRSize` in `{128, 256, 512}`, generate a QR and parse the PNG IHDR chunk; assert width === height === size
+
+  - [ ] 3.6 Implement creator info overlay and loading/error states
+    - Display `displayName` and `@username` adjacent to the QR code area
+    - Show a loading indicator while `isLoading` is true
+    - Show an inline error message when `error` is non-null (no `<img>` rendered)
+    - _Requirements: 1.4, 4.1, 4.2, 4.3_
+
+  - [ ]* 3.7 Write property test for creator info display (Property 5)
+    - **Property 5: Creator info is always displayed alongside the QR code**
+    - **Validates: Requirements 4.1, 4.2**
+    - For any `(displayName, username)` pair, render `QRCodePanel` and assert both display name and `@username` appear in output
+
+  - [ ] 3.8 Implement download button
+    - Add a "Download PNG" button that calls `handleDownload(dataUrl, username)` when `dataUrl` is non-null
+    - _Requirements: 3.1, 3.2, 3.3_
+
+  - [ ]* 3.9 Write unit tests for `QRCodePanel` rendering
+    - Assert `<img>` appears after async QR generation with a valid `profileUrl`
+    - Assert default selected size button is "M" on first render
+    - Assert loading indicator is shown while generation is in progress
+    - Assert download button triggers anchor with correct `download` attribute
+    - _Requirements: 2.3, 3.1, 4.3_
+
+- [ ] 4. Checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 5. Integrate `QRCodePanel` into `CreatorPage`
+  - [ ] 5.1 Update `src/app/creator/[username]/page.tsx`
+    - Construct `profileUrl` using `NEXT_PUBLIC_SITE_URL` env var with empty-string fallback
+    - Import and render `<QRCodePanel username={profile.username} displayName={profile.displayName} profileUrl={profileUrl} />` inside the profile card `<div>`, below the action buttons and above the tip form section
+    - _Requirements: 5.1, 5.2_
+
+  - [ ]* 5.2 Write unit test for `QRCodePanel` presence in `CreatorPage`
+    - Assert `QRCodePanel` is rendered inside the profile card section
+    - _Requirements: 5.1_
+
+- [ ] 6. Add responsive layout for mobile viewports
+  - Ensure `QRCodePanel` stacks its controls vertically on viewports narrower than 640px using Tailwind responsive classes
+  - _Requirements: 5.3_
+
+- [ ] 7. Add `NEXT_PUBLIC_SITE_URL` to `.env.example`
+  - Document the variable with a comment explaining its purpose for QR code URL construction
+  - _Requirements: 5.2_
+
+- [ ] 8. Final checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- Each task references specific requirements for traceability
+- Property tests use `fast-check` with a minimum of 100 iterations each
+- Unit tests use Vitest + React Testing Library


### PR DESCRIPTION
feat: add creator QR code spec

Summary
Introduces the full spec for QR code generation on creator profile pages. This is a spec-only PR — no implementation code yet. The spec covers requirements, technical design, and a sequenced implementation task list.

Motivation
Creator profiles currently have no shareable QR code. Adding one lets visitors scan a creator's profile URL directly from their phone, making it faster to share profiles and initiate tips on mobile without typing a URL.

What's in this PR
requirements.md Defines 5 requirements using EARS-style acceptance criteria:

R1 — QR code generated from the creator's canonical profile URL on page load
R2 — Three configurable sizes: 128px (S), 256px (M, default), 512px (L)
R3 — One-click PNG download named qr-<username>.png, with a window.open fallback for unsupported browsers
R4 — Creator display name and @username shown alongside the QR code, with a loading indicator during generation
R5 — Client-side only, no SSR blocking, responsive stacking on mobile viewports < 640px
design.md

Technology: qrcode npm library — runs in the browser, returns a base64 PNG via toDataURL, no canvas hacks needed
Architecture: CreatorPage (server component) passes username, displayName, and profileUrl as props to QRCodePanel ("use client")
QRCodePanel owns all ephemeral state: size, dataUrl, isLoading, error
Profile URL constructed from NEXT_PUBLIC_SITE_URL env var; empty string triggers the error state gracefully
Download via <a download> element; falls back to window.open when the attribute is unsupported
5 formal correctness properties defined for property-based testing with fast-check
Testing strategy: Vitest + React Testing Library for unit tests, fast-check (min 100 iterations) for property tests
tasks.md 8 sequenced implementation tasks:

Install qrcode, @types/qrcode, fast-check
Implement handleDownload utility + unit/property tests
Build QRCodePanel — QR generation, size selector, creator info overlay, download button + property tests
Checkpoint: all tests pass
Integrate QRCodePanel into CreatorPage
Responsive mobile layout (Tailwind)
Document NEXT_PUBLIC_SITE_URL in .env.example
Final checkpoint: all tests pass
Correctness Properties
#	Property	Validates
P1	QR encodes the full absolute profile URL (round-trip verified)	R1.1, R1.2, R1.3
P2	Size selection produces correct square pixel dimensions	R2.1, R2.2, R2.4
P3	Download filename matches qr-<username>.png	R3.2
P4	Empty/invalid profileUrl triggers error state, no <img> rendered	R1.4
P5	displayName and @username always present in rendered output	R4.1, R4.2
Environment Variables
NEXT_PUBLIC_SITE_URL — base URL for constructing the creator profile URL embedded in the QR code. Not required to run the app, but must be set for QR codes to function correctly. Will be documented in .env.example as part of task 7.

Reviewer Notes
No production code changes in this PR — safe to merge as a spec baseline
Optional sub-tasks (marked * in tasks.md) cover property-based tests and can be skipped for a faster MVP
Implementation can begin immediately by working through tasks.md sequentially

Closes #13 