### PR TITLE
feat: add analytics dashboard spec (requirements, design, tasks)

### DIFF
--- a/.kiro/specs/analytics-dashboard/.config.kiro
+++ b/.kiro/specs/analytics-dashboard/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "17d73d9d-4bd0-4563-8953-64d2fc786fad", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/analytics-dashboard/design.md
+++ b/.kiro/specs/analytics-dashboard/design.md
@@ -1,0 +1,212 @@
+# Design Document: Analytics Dashboard
+
+## Overview
+
+The Analytics Dashboard is a new page at `/analytics` that surfaces platform-wide statistics for the Stellar Tip Jar platform. It provides stakeholders with interactive charts, summary stat cards, a top-creators leaderboard, and a report export capability — all scoped to a user-selected time range.
+
+The feature is built entirely on the existing Next.js 14 (App Router) frontend. Data is fetched from the `Analytics_API` backend endpoint. The UI follows the existing design system (Tailwind tokens: `canvas`, `ink`, `wave`, `sunrise`, `moss`; `shadow-card`; `rounded-2xl` surfaces).
+
+No new backend is introduced in this spec. The frontend consumes a single analytics endpoint and delegates all aggregation to the server.
+
+---
+
+## Architecture
+
+```mermaid
+graph TD
+    A["/analytics page (RSC shell)"] --> B["AnalyticsDashboard (client component)"]
+    B --> C["useAnalytics hook"]
+    C --> D["analyticsApi service"]
+    D --> E["Analytics_API backend"]
+    B --> F["TimeRangeSelector"]
+    B --> G["StatCardGrid"]
+    B --> H["UserGrowthChart"]
+    B --> I["TipVolumeChart"]
+    B --> J["TopCreatorsLeaderboard"]
+    B --> K["ExportButton"]
+    B --> L["RefreshButton + LastFetchedAt"]
+    K --> M["exportService (client-side)"]
+```
+
+The page shell (`/analytics/page.tsx`) is a React Server Component that renders the `<AnalyticsDashboard>` client component. All interactivity (time range selection, chart hover, export, refresh) lives inside the client component tree.
+
+Data flow:
+1. `AnalyticsDashboard` mounts → calls `useAnalytics(timeRange)`.
+2. `useAnalytics` calls `analyticsApi.getMetrics(timeRange)` via the existing `request()` helper in `src/services/api.ts`.
+3. On success, state is distributed to child components via props.
+4. On error, an inline error banner is shown; previously loaded data remains visible.
+5. Time range changes trigger a new fetch; the UI shows a loading overlay and disables the selector.
+
+---
+
+## Components and Interfaces
+
+### `AnalyticsDashboard` (client component)
+Central orchestrator. Owns `timeRange` state, delegates to `useAnalytics`, and passes data down.
+
+```ts
+interface AnalyticsDashboardProps {} // no external props; self-contained
+```
+
+### `TimeRangeSelector`
+Renders four buttons (7d / 30d / 90d / 1y). Disabled while loading.
+
+```ts
+interface TimeRangeSelectorProps {
+  value: TimeRange;
+  onChange: (range: TimeRange) => void;
+  disabled: boolean;
+}
+```
+
+### `StatCard`
+Displays a single metric value and its period-over-period trend badge.
+
+```ts
+interface StatCardProps {
+  label: string;
+  value: string | number;
+  trend?: number;       // percentage, positive = up, negative = down
+  loading: boolean;
+}
+```
+
+### `UserGrowthChart`
+Line chart (Recharts `LineChart`) of cumulative creator registrations.
+
+```ts
+interface UserGrowthChartProps {
+  data: GrowthDataPoint[];
+  loading: boolean;
+  empty: boolean;
+}
+```
+
+### `TipVolumeChart`
+Bar chart (Recharts `BarChart`) of XLM tip volume per interval.
+
+```ts
+interface TipVolumeChartProps {
+  data: VolumeDataPoint[];
+  trend: number;        // period-over-period % change
+  loading: boolean;
+  empty: boolean;
+}
+```
+
+### `TopCreatorsLeaderboard`
+Ranked list of top 10 creators. Each row is a `<Link>` to `/creator/[username]`.
+
+```ts
+interface TopCreatorsLeaderboardProps {
+  creators: TopCreator[];
+  loading: boolean;
+}
+```
+
+### `ExportButton`
+Dropdown to choose CSV or JSON, then triggers `exportService.download()`.
+
+```ts
+interface ExportButtonProps {
+  metrics: AnalyticsMetrics | null;
+  timeRange: TimeRange;
+  disabled: boolean;    // true while loading
+}
+```
+
+### `RefreshButton`
+Icon button that calls `refetch()` from `useAnalytics`. Shows spinner while refreshing.
+
+```ts
+interface RefreshButtonProps {
+  onRefresh: () => void;
+  loading: boolean;
+  lastFetchedAt: Date | null;
+}
+```
+
+### `analyticsApi` service (`src/services/analyticsApi.ts`)
+Thin wrapper around the shared `request()` helper.
+
+```ts
+function getMetrics(timeRange: TimeRange): Promise<AnalyticsMetrics>
+```
+
+### `exportService` (`src/utils/exportService.ts`)
+Pure client-side module; no network calls.
+
+```ts
+function download(metrics: AnalyticsMetrics, timeRange: TimeRange, format: ExportFormat): void
+```
+
+### `useAnalytics` hook (`src/hooks/useAnalytics.ts`)
+
+```ts
+function useAnalytics(timeRange: TimeRange): {
+  metrics: AnalyticsMetrics | null;
+  loading: boolean;
+  error: Error | null;
+  lastFetchedAt: Date | null;
+  refetch: () => void;
+}
+```
+
+---
+
+## Data Models
+
+```ts
+// Supported time range values
+type TimeRange = "7d" | "30d" | "90d" | "1y";
+
+// Export format options
+type ExportFormat = "csv" | "json";
+
+// A single data point in the growth or volume chart
+interface GrowthDataPoint {
+  label: string;        // e.g. "2024-01-15" (daily) or "2024-W03" (weekly)
+  count: number;        // cumulative creator count
+}
+
+interface VolumeDataPoint {
+  label: string;        // same interval labelling as GrowthDataPoint
+  xlm: number;          // total XLM tipped in this interval
+}
+
+interface TopCreator {
+  rank: number;
+  username: string;
+  tipCount: number;
+  totalXlm: number;
+}
+
+interface StatsSummary {
+  totalTipsCount: number;
+  totalTipsXlm: number;
+  totalCreators: number;
+  activeCreators: number;          // within selected time range
+}
+
+// Full response shape from Analytics_API
+interface AnalyticsMetrics {
+  timeRange: TimeRange;
+  fetchedAt: string;               // ISO 8601 timestamp
+  summary: StatsSummary;
+  growthData: GrowthDataPoint[];
+  volumeData: VolumeDataPoint[];
+  volumeTrend: number;             // period-over-period % for tip volume
+  topCreators: TopCreator[];
+}
+```
+
+**Charting library**: [Recharts](https://recharts.org/) — React-native, composable, well-maintained, and SSR-safe (renders nothing on server, hydrates on client). It will be added as a dependency.
+
+**Interval logic** (shared between API response and chart rendering):
+- `7d` and `30d` → daily data points
+- `90d` and `1y` → weekly data points
+
+The interval granularity is determined server-side and reflected in the `label` field of each data point. The frontend does not re-aggregate.
+
+**File naming for exports**: `analytics-{timeRange}-{YYYY-MM-DD}.{format}` — e.g. `analytics-30d-2024-07-15.csv`.
+

--- a/.kiro/specs/analytics-dashboard/requirements.md
+++ b/.kiro/specs/analytics-dashboard/requirements.md
@@ -1,0 +1,116 @@
+# Requirements Document
+
+## Introduction
+
+The Analytics Dashboard provides platform-wide statistics and visualizations for the Stellar Tip Jar platform. It surfaces key metrics including user growth, tip volume, transaction trends, and creator activity through interactive charts. Administrators and platform stakeholders can view aggregated data over configurable time ranges and export reports for offline analysis.
+
+## Glossary
+
+- **Dashboard**: The analytics page at `/analytics` that renders all platform statistics and charts.
+- **Analytics_API**: The backend service endpoint that aggregates and returns platform metrics data.
+- **Chart**: An interactive SVG-based visualization rendered in the browser using a charting library.
+- **Metric**: A single quantitative measurement (e.g., total tips sent, active users).
+- **Time_Range**: A user-selected period (7 days, 30 days, 90 days, 1 year) used to filter metric data.
+- **Report**: A downloadable file (CSV or JSON) containing the currently displayed metric data.
+- **Stat_Card**: A UI component displaying a single Metric with its current value and period-over-period change.
+- **Trend**: The directional change of a Metric over a Time_Range, expressed as a percentage.
+- **Export_Service**: The client-side module responsible for generating and triggering Report downloads.
+- **Creator**: A registered platform user with a public profile who receives tips.
+
+---
+
+## Requirements
+
+### Requirement 1: Platform Statistics Overview
+
+**User Story:** As a platform stakeholder, I want to see high-level platform statistics at a glance, so that I can quickly assess overall platform health.
+
+#### Acceptance Criteria
+
+1. THE Dashboard SHALL display a Stat_Card for total tips sent (count).
+2. THE Dashboard SHALL display a Stat_Card for total tip volume (XLM amount).
+3. THE Dashboard SHALL display a Stat_Card for total registered Creators.
+4. THE Dashboard SHALL display a Stat_Card for active Creators within the selected Time_Range.
+5. WHEN metric data is loading, THE Dashboard SHALL display a skeleton loading state for each Stat_Card.
+6. IF the Analytics_API returns an error, THEN THE Dashboard SHALL display an error message and a retry action without hiding previously loaded data.
+
+---
+
+### Requirement 2: Time Range Selection
+
+**User Story:** As a platform stakeholder, I want to filter all metrics by a time range, so that I can analyze trends over different periods.
+
+#### Acceptance Criteria
+
+1. THE Dashboard SHALL provide Time_Range options of 7 days, 30 days, 90 days, and 1 year.
+2. WHEN a Time_Range is selected, THE Dashboard SHALL re-fetch all metric data for that period.
+3. THE Dashboard SHALL default to the 30-day Time_Range on initial load.
+4. WHILE a Time_Range change is in progress, THE Dashboard SHALL display a loading indicator and disable further Time_Range selection.
+
+---
+
+### Requirement 3: User Growth Chart
+
+**User Story:** As a platform stakeholder, I want to see a chart of user growth over time, so that I can understand platform adoption trends.
+
+#### Acceptance Criteria
+
+1. THE Dashboard SHALL render a line Chart showing cumulative Creator registrations over the selected Time_Range.
+2. THE Chart SHALL display data points at daily intervals for Time_Range values of 7 days and 30 days.
+3. THE Chart SHALL display data points at weekly intervals for Time_Range values of 90 days and 1 year.
+4. WHEN a data point is hovered, THE Chart SHALL display a tooltip showing the date and cumulative Creator count.
+5. IF no registration data exists for the selected Time_Range, THEN THE Chart SHALL display an empty-state message.
+
+---
+
+### Requirement 4: Tip Volume Chart
+
+**User Story:** As a platform stakeholder, I want to see a chart of tip volume over time, so that I can track transaction activity and revenue trends.
+
+#### Acceptance Criteria
+
+1. THE Dashboard SHALL render a bar Chart showing total tip volume (XLM) aggregated per interval over the selected Time_Range.
+2. THE Chart SHALL use the same interval rules as Requirement 3 (daily for ≤30 days, weekly for ≥90 days).
+3. WHEN a bar is hovered, THE Chart SHALL display a tooltip showing the interval label and total XLM volume.
+4. THE Chart SHALL display the Trend percentage for the selected Time_Range compared to the equivalent prior period.
+5. IF no tip data exists for the selected Time_Range, THEN THE Chart SHALL display an empty-state message.
+
+---
+
+### Requirement 5: Top Creators Leaderboard
+
+**User Story:** As a platform stakeholder, I want to see which creators are receiving the most tips, so that I can identify top performers on the platform.
+
+#### Acceptance Criteria
+
+1. THE Dashboard SHALL display a ranked list of the top 10 Creators by tip volume within the selected Time_Range.
+2. THE Dashboard SHALL show each Creator's rank, username, tip count, and total XLM received.
+3. WHEN a Creator entry is clicked, THE Dashboard SHALL navigate to that Creator's profile page.
+4. IF fewer than 10 Creators have received tips in the selected Time_Range, THE Dashboard SHALL display only the available entries.
+
+---
+
+### Requirement 6: Report Export
+
+**User Story:** As a platform stakeholder, I want to export the current dashboard data as a report, so that I can analyze it offline or share it with others.
+
+#### Acceptance Criteria
+
+1. THE Dashboard SHALL provide an export action that triggers a Report download.
+2. THE Export_Service SHALL support CSV and JSON as Report formats.
+3. WHEN an export format is selected, THE Export_Service SHALL generate a Report containing all currently displayed metric data for the active Time_Range.
+4. THE Export_Service SHALL name the downloaded file using the pattern `analytics-{time_range}-{YYYY-MM-DD}.{format}`.
+5. IF the metric data has not finished loading, THEN THE Dashboard SHALL disable the export action until loading is complete.
+
+---
+
+### Requirement 7: Data Freshness and Caching
+
+**User Story:** As a platform stakeholder, I want the dashboard data to be reasonably current, so that I am making decisions based on recent platform activity.
+
+#### Acceptance Criteria
+
+1. THE Analytics_API SHALL return data with a maximum staleness of 5 minutes.
+2. THE Dashboard SHALL display the timestamp of the last successful data fetch.
+3. THE Dashboard SHALL provide a manual refresh action that re-fetches all metric data for the current Time_Range.
+4. WHILE a manual refresh is in progress, THE Dashboard SHALL display a loading indicator on the refresh action.

--- a/.kiro/specs/analytics-dashboard/tasks.md
+++ b/.kiro/specs/analytics-dashboard/tasks.md
@@ -1,0 +1,170 @@
+# Implementation Plan: Analytics Dashboard
+
+## Overview
+
+Implement the analytics dashboard as a new `/analytics` route in the existing Next.js 14 App Router project. The work proceeds in layers: types and service → data hook → UI components → page wiring → export utility → final integration.
+
+## Tasks
+
+- [ ] 1. Define shared types and add Recharts dependency
+  - Create `src/types/analytics.ts` with `TimeRange`, `ExportFormat`, `GrowthDataPoint`, `VolumeDataPoint`, `TopCreator`, `StatsSummary`, and `AnalyticsMetrics` types
+  - Add `recharts` and `@types/recharts` to `package.json` dependencies
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 3.1, 4.1, 5.1, 6.2_
+
+- [ ] 2. Implement `analyticsApi` service
+  - [ ] 2.1 Create `src/services/analyticsApi.ts` with `getMetrics(timeRange: TimeRange): Promise<AnalyticsMetrics>` using the shared `request()` helper from `src/services/api.ts`
+    - Call `GET /analytics?timeRange={timeRange}`
+    - _Requirements: 1.6, 2.2, 7.1_
+
+  - [ ]* 2.2 Write unit tests for `analyticsApi`
+    - Test successful fetch returns typed `AnalyticsMetrics`
+    - Test that API errors propagate as `Error` instances
+    - _Requirements: 1.6_
+
+- [ ] 3. Implement `useAnalytics` hook
+  - [ ] 3.1 Create `src/hooks/useAnalytics.ts` returning `{ metrics, loading, error, lastFetchedAt, refetch }`
+    - Default `timeRange` to `"30d"` on mount
+    - Re-fetch when `timeRange` argument changes
+    - Preserve previously loaded `metrics` on error (do not clear on re-fetch failure)
+    - Set `lastFetchedAt` to `new Date()` on each successful response
+    - _Requirements: 1.5, 1.6, 2.2, 2.3, 2.4, 7.2, 7.3, 7.4_
+
+  - [ ]* 3.2 Write property test for `useAnalytics` — Property 1: error preservation
+    - **Property 1: Previously loaded metrics are never cleared on a subsequent fetch error**
+    - **Validates: Requirements 1.6**
+
+  - [ ]* 3.3 Write property test for `useAnalytics` — Property 2: loading state consistency
+    - **Property 2: `loading` is true for the entire duration of any fetch and false otherwise**
+    - **Validates: Requirements 2.4, 7.4**
+
+- [ ] 4. Implement `StatCard` component
+  - [ ] 4.1 Create `src/components/analytics/StatCard.tsx`
+    - Render `label`, formatted `value`, and optional `trend` badge (green up-arrow / red down-arrow)
+    - Render skeleton placeholder when `loading` is true
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
+
+  - [ ]* 4.2 Write unit tests for `StatCard`
+    - Test skeleton renders when `loading=true`
+    - Test positive trend shows green badge, negative shows red badge
+    - _Requirements: 1.5_
+
+- [ ] 5. Implement `TimeRangeSelector` component
+  - [ ] 5.1 Create `src/components/analytics/TimeRangeSelector.tsx`
+    - Render four buttons: 7d / 30d / 90d / 1y
+    - Highlight the active `value`; disable all buttons when `disabled` is true
+    - _Requirements: 2.1, 2.3, 2.4_
+
+  - [ ]* 5.2 Write unit tests for `TimeRangeSelector`
+    - Test all four options render
+    - Test buttons are disabled when `disabled=true`
+    - Test `onChange` fires with correct value on click
+    - _Requirements: 2.1, 2.4_
+
+- [ ] 6. Implement chart components
+  - [ ] 6.1 Create `src/components/analytics/UserGrowthChart.tsx` using Recharts `LineChart`
+    - Show skeleton/spinner when `loading=true`
+    - Show empty-state message when `empty=true`
+    - Enable `<Tooltip>` showing date and cumulative count on hover
+    - _Requirements: 3.1, 3.4, 3.5_
+
+  - [ ]* 6.2 Write unit tests for `UserGrowthChart`
+    - Test empty-state renders when `empty=true`
+    - Test loading state renders when `loading=true`
+    - _Requirements: 3.5_
+
+  - [ ] 6.3 Create `src/components/analytics/TipVolumeChart.tsx` using Recharts `BarChart`
+    - Display `trend` percentage label above the chart
+    - Show skeleton/spinner when `loading=true`
+    - Show empty-state message when `empty=true`
+    - Enable `<Tooltip>` showing interval label and XLM volume on hover
+    - _Requirements: 4.1, 4.3, 4.4, 4.5_
+
+  - [ ]* 6.4 Write unit tests for `TipVolumeChart`
+    - Test trend percentage renders correctly for positive and negative values
+    - Test empty-state renders when `empty=true`
+    - _Requirements: 4.4, 4.5_
+
+- [ ] 7. Implement `TopCreatorsLeaderboard` component
+  - [ ] 7.1 Create `src/components/analytics/TopCreatorsLeaderboard.tsx`
+    - Render ranked rows with rank, username, tip count, and total XLM
+    - Each row is a Next.js `<Link href="/creator/[username]">`
+    - Show skeleton rows when `loading=true`
+    - Render only available entries when fewer than 10 exist
+    - _Requirements: 5.1, 5.2, 5.3, 5.4_
+
+  - [ ]* 7.2 Write unit tests for `TopCreatorsLeaderboard`
+    - Test each row links to the correct creator profile URL
+    - Test partial list renders without errors
+    - _Requirements: 5.3, 5.4_
+
+- [ ] 8. Implement `exportService` and `ExportButton`
+  - [ ] 8.1 Create `src/utils/exportService.ts` with `download(metrics, timeRange, format)` — pure client-side, no network calls
+    - CSV: serialize `summary`, `growthData`, `volumeData`, `topCreators` sections
+    - JSON: `JSON.stringify` the full `AnalyticsMetrics` object
+    - Filename pattern: `analytics-{timeRange}-{YYYY-MM-DD}.{format}`
+    - Trigger download via a temporary `<a>` element with `Blob` URL
+    - _Requirements: 6.1, 6.2, 6.3, 6.4_
+
+  - [ ]* 8.2 Write property test for `exportService` — Property 3: filename determinism
+    - **Property 3: For any valid `(timeRange, date)` pair the filename always matches `analytics-{timeRange}-{YYYY-MM-DD}.{format}`**
+    - **Validates: Requirements 6.4**
+
+  - [ ]* 8.3 Write property test for `exportService` — Property 4: JSON round-trip
+    - **Property 4: JSON export parsed back to an object equals the original `AnalyticsMetrics` value**
+    - **Validates: Requirements 6.3**
+
+  - [ ] 8.4 Create `src/components/analytics/ExportButton.tsx`
+    - Dropdown with CSV and JSON options
+    - Disabled when `disabled=true` (loading in progress)
+    - Calls `exportService.download()` on selection
+    - _Requirements: 6.1, 6.2, 6.5_
+
+  - [ ]* 8.5 Write unit tests for `ExportButton`
+    - Test button is disabled when `disabled=true`
+    - Test `exportService.download` is called with correct format on selection
+    - _Requirements: 6.5_
+
+- [ ] 9. Checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 10. Implement `RefreshButton` component
+  - [ ] 10.1 Create `src/components/analytics/RefreshButton.tsx`
+    - Icon button that calls `onRefresh`
+    - Shows spinner icon while `loading=true`
+    - Displays `lastFetchedAt` timestamp next to the button (e.g. "Last updated 2 min ago")
+    - _Requirements: 7.2, 7.3, 7.4_
+
+  - [ ]* 10.2 Write unit tests for `RefreshButton`
+    - Test spinner renders when `loading=true`
+    - Test `onRefresh` is called on click
+    - _Requirements: 7.3, 7.4_
+
+- [ ] 11. Assemble `AnalyticsDashboard` client component
+  - [ ] 11.1 Create `src/components/analytics/AnalyticsDashboard.tsx`
+    - Own `timeRange` state (default `"30d"`)
+    - Call `useAnalytics(timeRange)` and distribute `metrics`, `loading`, `error`, `lastFetchedAt`, `refetch` to child components
+    - Render inline error banner when `error` is set; keep previously loaded data visible
+    - Render `TimeRangeSelector`, four `StatCard`s, `UserGrowthChart`, `TipVolumeChart`, `TopCreatorsLeaderboard`, `ExportButton`, and `RefreshButton`
+    - Derive `empty` flags from `metrics?.growthData.length === 0` and `metrics?.volumeData.length === 0`
+    - _Requirements: 1.1–1.6, 2.1–2.4, 3.1–3.5, 4.1–4.5, 5.1–5.4, 6.1–6.5, 7.2–7.4_
+
+  - [ ]* 11.2 Write integration tests for `AnalyticsDashboard`
+    - Mock `analyticsApi.getMetrics` to return fixture data; assert all stat cards render
+    - Mock API error; assert error banner appears and previous data remains visible
+    - _Requirements: 1.5, 1.6, 2.4_
+
+- [ ] 12. Create `/analytics` page route
+  - Create `src/app/analytics/page.tsx` as a React Server Component that renders `<AnalyticsDashboard />`
+  - Add `"use client"` directive only to `AnalyticsDashboard`, not the page shell
+  - _Requirements: 1.1, 2.1_
+
+- [ ] 13. Final checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- Each task references specific requirements for traceability
+- Recharts renders nothing on the server and hydrates on the client — no SSR issues
+- `exportService` must only run in the browser; guard with `typeof window !== "undefined"` if imported in shared modules
+- Property tests validate universal correctness properties; unit tests validate specific examples and edge cases


### PR DESCRIPTION
feat: add analytics dashboard spec

Summary
Adds the full spec for the analytics dashboard feature. Spec-only PR — no implementation code yet.

What's included
requirements.md — 7 requirements:

R1 — Platform stats overview (4 stat cards: tip count, XLM volume, total/active creators)
R2 — Time range filter (7d / 30d / 90d / 1y, defaults to 30d)
R3 — User growth line chart with daily/weekly intervals and hover tooltips
R4 — Tip volume bar chart with trend % vs prior period
R5 — Top 10 creators leaderboard, clickable to profile pages
R6 — Report export as CSV or JSON, filename analytics-{timeRange}-{YYYY-MM-DD}.{format}
R7 — Data freshness: max 5min staleness, last-fetched timestamp, manual refresh
design.md — Architecture (RSC shell + AnalyticsDashboard client component), full component interfaces, data models, Recharts as charting library, exportService as a pure client-side utility, and 4 correctness properties for property-based testing.

tasks.md — 13 sequenced implementation tasks covering types, analyticsApi service, useAnalytics hook, all UI components, exportService, page route, and two checkpoints. Optional test sub-tasks marked *.

Reviewer Notes
No production code changes — safe to merge as a spec baseline
Implementation starts at 
analytics.ts
 and proceeds layer by layer through tasks.md
recharts will be added as a dependency in task 1

Closes #17 