### PR TITLE
feat(perf): add Web Vitals monitoring

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter } from "next/font/google";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { InstallPrompt } from "@/components/InstallPrompt";
 import { Navbar } from "@/components/Navbar";
+import { PerformanceMonitor } from "@/components/PerformanceMonitor";
 import { ReactQueryProvider } from "@/components/ReactQueryProvider";
 import { SkipToContent } from "@/components/SkipToContent";
 import { WalletProvider } from "@/contexts/WalletContext";
@@ -47,6 +48,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
         <SkipToContent />
+        <PerformanceMonitor />
         <WalletProvider>
           <ReactQueryProvider>
           <div className="min-h-screen">

--- a/src/components/PerformanceMonitor.tsx
+++ b/src/components/PerformanceMonitor.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { reportWebVitals } from "@/lib/webVitals";
+
+/**
+ * Invisible component that bootstraps Web Vitals reporting.
+ * Mount once in the root layout (client-side only).
+ */
+export function PerformanceMonitor() {
+  useEffect(() => {
+    reportWebVitals();
+  }, []);
+
+  return null;
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,40 @@
+import type { Metric } from "web-vitals";
+
+export type AnalyticsMetric = {
+  name: string;
+  value: number;
+  rating: "good" | "needs-improvement" | "poor";
+  delta: number;
+  id: string;
+  navigationType: string;
+};
+
+/**
+ * Sends a Web Vitals metric to the analytics endpoint.
+ * Uses sendBeacon when available for non-blocking delivery,
+ * falls back to fetch with keepalive.
+ */
+export function sendToAnalytics(metric: Metric): void {
+  const payload: AnalyticsMetric = {
+    name: metric.name,
+    value: metric.value,
+    rating: metric.rating,
+    delta: metric.delta,
+    id: metric.id,
+    navigationType: metric.navigationType,
+  };
+
+  const body = JSON.stringify(payload);
+  const url = "/api/analytics";
+
+  if (navigator.sendBeacon) {
+    navigator.sendBeacon(url, body);
+  } else {
+    fetch(url, {
+      body,
+      method: "POST",
+      keepalive: true,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/src/lib/webVitals.ts
+++ b/src/lib/webVitals.ts
@@ -1,0 +1,50 @@
+import { onCLS, onFCP, onINP, onLCP, onTTFB } from "web-vitals";
+
+import { sendToAnalytics } from "./analytics";
+
+/**
+ * Performance budgets based on Google's Core Web Vitals thresholds.
+ * Values are in milliseconds (or unitless for CLS).
+ */
+export const PERFORMANCE_BUDGETS = {
+  LCP: { good: 2500, poor: 4000 },   // Largest Contentful Paint
+  INP: { good: 200, poor: 500 },     // Interaction to Next Paint
+  CLS: { good: 0.1, poor: 0.25 },   // Cumulative Layout Shift
+  FCP: { good: 1800, poor: 3000 },   // First Contentful Paint
+  TTFB: { good: 800, poor: 1800 },   // Time to First Byte
+} as const;
+
+export type MetricName = keyof typeof PERFORMANCE_BUDGETS;
+
+/**
+ * Checks a metric value against the performance budget and warns in dev.
+ */
+function checkBudget(name: MetricName, value: number): void {
+  if (process.env.NODE_ENV !== "development") return;
+
+  const budget = PERFORMANCE_BUDGETS[name];
+  if (value > budget.poor) {
+    console.warn(`[WebVitals] ⚠️ ${name} is POOR: ${value} (budget: ${budget.poor})`);
+  } else if (value > budget.good) {
+    console.info(`[WebVitals] 🟡 ${name} needs improvement: ${value} (budget: ${budget.good})`);
+  } else {
+    console.info(`[WebVitals] ✅ ${name} is GOOD: ${value}`);
+  }
+}
+
+/**
+ * Registers all Core Web Vitals observers and pipes metrics to analytics.
+ * Call once at app initialization (e.g. in layout.tsx via a client component).
+ */
+export function reportWebVitals(): void {
+  const report = (metric: Parameters<typeof sendToAnalytics>[0]) => {
+    checkBudget(metric.name as MetricName, metric.value);
+    sendToAnalytics(metric);
+  };
+
+  onCLS(report);
+  onFCP(report);
+  onINP(report);
+  onLCP(report);
+  onTTFB(report);
+}

--- a/src/utils/performanceUtils.ts
+++ b/src/utils/performanceUtils.ts
@@ -1,0 +1,64 @@
+import { PERFORMANCE_BUDGETS, type MetricName } from "@/lib/webVitals";
+
+export type MetricRating = "good" | "needs-improvement" | "poor";
+
+/**
+ * Returns the rating for a given metric value against its budget.
+ */
+export function getMetricRating(name: MetricName, value: number): MetricRating {
+  const budget = PERFORMANCE_BUDGETS[name];
+  if (value <= budget.good) return "good";
+  if (value <= budget.poor) return "needs-improvement";
+  return "poor";
+}
+
+/**
+ * Formats a metric value for display.
+ * CLS is unitless; all others are in ms.
+ */
+export function formatMetricValue(name: MetricName, value: number): string {
+  if (name === "CLS") return value.toFixed(3);
+  return `${Math.round(value)}ms`;
+}
+
+/**
+ * Measures the duration of an async operation using the Performance API.
+ */
+export async function measureAsync<T>(
+  name: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const start = performance.now();
+  try {
+    return await fn();
+  } finally {
+    const duration = performance.now() - start;
+    if (process.env.NODE_ENV === "development") {
+      console.debug(`[Perf] ${name}: ${duration.toFixed(2)}ms`);
+    }
+    // Mark for DevTools Performance panel
+    performance.measure(name, { start, duration });
+  }
+}
+
+/**
+ * Returns a snapshot of navigation timing metrics from the browser.
+ */
+export function getNavigationTiming(): Record<string, number> | null {
+  if (typeof window === "undefined") return null;
+
+  const [entry] = performance.getEntriesByType(
+    "navigation"
+  ) as PerformanceNavigationTiming[];
+  if (!entry) return null;
+
+  return {
+    dns: entry.domainLookupEnd - entry.domainLookupStart,
+    tcp: entry.connectEnd - entry.connectStart,
+    ttfb: entry.responseStart - entry.requestStart,
+    download: entry.responseEnd - entry.responseStart,
+    domInteractive: entry.domInteractive,
+    domComplete: entry.domComplete,
+    loadEvent: entry.loadEventEnd - entry.loadEventStart,
+  };
+}


### PR DESCRIPTION
## Summary

Implements Real User Monitoring (RUM) via Core Web Vitals using the `web-vitals` v5 library (already in dependencies).

## Changes

- `src/lib/webVitals.ts` — registers CLS, FCP, INP, LCP, TTFB observers with performance budget thresholds and dev-mode console warnings
- `src/lib/analytics.ts` — `sendToAnalytics` helper using `sendBeacon` with `fetch` fallback to `/api/analytics`
- `src/utils/performanceUtils.ts` — metric rating, value formatting, async measurement helper, and navigation timing snapshot
- `src/components/PerformanceMonitor.tsx` — client component that bootstraps vitals reporting on mount
- `src/app/layout.tsx` — mounts `<PerformanceMonitor />` at the root

## Performance Budgets

| Metric | Good | Poor |
|--------|------|------|
| LCP | ≤2500ms | >4000ms |
| INP | ≤200ms | >500ms |
| CLS | ≤0.1 | >0.25 |
| FCP | ≤1800ms | >3000ms |
| TTFB | ≤800ms | >1800ms |

> Note: FID is excluded — web-vitals v4+ replaced it with INP.

closes #27 