### PR TITLE
feat(tips): add receipt generation and download

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,15 @@
     "react-hot-toast": "^2.6.0",
     "recharts": "^3.8.1",
     "socket.io-client": "^4.8.3",
+    "jspdf": "^3.0.1",
+    "qrcode": "^1.5.4",
     "web-vitals": "^5.2.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@types/node": "^25",
+    "@types/qrcode": "^1.5.5",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitest/coverage-v8": "^4.1.1",

--- a/src/components/TipHistoryTable.tsx
+++ b/src/components/TipHistoryTable.tsx
@@ -101,6 +101,7 @@ export function TipHistoryTable({ tips, onSort, sortBy, sortOrder }: TipHistoryT
               </th>
               <th className="px-4 py-3 text-left text-sm font-semibold text-ink">Memo</th>
               <th className="px-4 py-3 text-left text-sm font-semibold text-ink">Transaction</th>
+              <th className="px-4 py-3 text-left text-sm font-semibold text-ink">Actions</th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/TipRow.tsx
+++ b/src/components/TipRow.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useState } from "react";
 import type { Tip } from "@/hooks/useTipHistory";
+import { generateReceiptPDF } from "@/utils/pdfGenerator";
 
 interface TipRowProps {
   tip: Tip;
@@ -19,6 +21,8 @@ const statusLabels = {
 };
 
 export function TipRow({ tip }: TipRowProps) {
+  const [isGenerating, setIsGenerating] = useState(false);
+
   const formattedDate = new Date(tip.date).toLocaleDateString("en-US", {
     year: "numeric",
     month: "short",
@@ -26,6 +30,15 @@ export function TipRow({ tip }: TipRowProps) {
     hour: "2-digit",
     minute: "2-digit",
   });
+
+  const handleDownloadReceipt = async () => {
+    setIsGenerating(true);
+    try {
+      await generateReceiptPDF(tip);
+    } finally {
+      setIsGenerating(false);
+    }
+  };
 
   return (
     <tr className="border-b border-ink/10 hover:bg-ink/5">
@@ -65,6 +78,27 @@ export function TipRow({ tip }: TipRowProps) {
         ) : (
           <span className="text-ink/40">-</span>
         )}
+      </td>
+      <td className="px-4 py-3">
+        <button
+          type="button"
+          onClick={handleDownloadReceipt}
+          disabled={isGenerating}
+          className="inline-flex items-center gap-1 rounded-md bg-wave/10 px-2 py-1 text-xs font-medium text-wave hover:bg-wave/20 disabled:cursor-not-allowed disabled:opacity-50"
+          title="Download receipt"
+        >
+          {isGenerating ? (
+            <svg className="h-3 w-3 animate-spin" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+          ) : (
+            <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+          )}
+          Receipt
+        </button>
       </td>
     </tr>
   );

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -1,0 +1,94 @@
+import { jsPDF } from "jspdf";
+import QRCode from "qrcode";
+import type { Tip } from "@/hooks/queries/useTips";
+
+const STELLAR_EXPLORER_URL = "https://stellar.expert/explorer/public/tx";
+
+export async function generateReceiptPDF(tip: Tip): Promise<void> {
+  const doc = new jsPDF();
+  const pageWidth = doc.internal.pageSize.getWidth();
+
+  doc.setFontSize(20);
+  doc.setFont("helvetica", "bold");
+  doc.text("Tip Receipt", pageWidth / 2, 25, { align: "center" });
+
+  doc.setFontSize(10);
+  doc.setFont("helvetica", "normal");
+  doc.setTextColor(100);
+  doc.text("Stellar Tip Jar", pageWidth / 2, 32, { align: "center" });
+
+  doc.setDrawColor(200);
+  doc.line(20, 40, pageWidth - 20, 40);
+
+  doc.setTextColor(0);
+  doc.setFontSize(11);
+  const startY = 55;
+  const lineHeight = 10;
+  const labelX = 25;
+  const valueX = 70;
+
+  const formattedDate = new Date(tip.date).toLocaleString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+
+  const fields = [
+    { label: "Receipt ID:", value: tip.id },
+    { label: "Date:", value: formattedDate },
+    { label: "Amount:", value: `${tip.amount} XLM` },
+    { label: "Recipient:", value: `@${tip.recipient}` },
+    { label: "Sender:", value: tip.sender },
+    { label: "Status:", value: tip.status.charAt(0).toUpperCase() + tip.status.slice(1) },
+    { label: "Memo:", value: tip.memo || "-" },
+  ];
+
+  fields.forEach((field, index) => {
+    const y = startY + index * lineHeight;
+    doc.setFont("helvetica", "bold");
+    doc.text(field.label, labelX, y);
+    doc.setFont("helvetica", "normal");
+    doc.text(field.value, valueX, y);
+  });
+
+  if (tip.transactionHash) {
+    const txY = startY + fields.length * lineHeight;
+    doc.setFont("helvetica", "bold");
+    doc.text("Transaction Hash:", labelX, txY);
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(9);
+    doc.text(tip.transactionHash, labelX, txY + 6);
+
+    const txUrl = `${STELLAR_EXPLORER_URL}/${tip.transactionHash}`;
+    const qrDataUrl = await QRCode.toDataURL(txUrl, {
+      width: 200,
+      margin: 1,
+    });
+
+    const qrSize = 50;
+    const qrX = (pageWidth - qrSize) / 2;
+    const qrY = txY + 20;
+    doc.addImage(qrDataUrl, "PNG", qrX, qrY, qrSize, qrSize);
+
+    doc.setFontSize(8);
+    doc.setTextColor(100);
+    doc.text("Scan to verify on Stellar Explorer", pageWidth / 2, qrY + qrSize + 6, {
+      align: "center",
+    });
+  }
+
+  doc.setFontSize(8);
+  doc.setTextColor(150);
+  doc.text(
+    `Generated on ${new Date().toLocaleString()}`,
+    pageWidth / 2,
+    doc.internal.pageSize.getHeight() - 15,
+    { align: "center" }
+  );
+
+  const timestamp = new Date().toISOString().split("T")[0];
+  doc.save(`tip-receipt-${tip.id}-${timestamp}.pdf`);
+}


### PR DESCRIPTION

Closes #74
## Summary

Implements PDF receipt generation for tip transactions to provide users with downloadable records of their payments.

## Root Cause

The application lacked any receipt generation functionality. Users could only export all tips as CSV but had no way to generate individual transaction receipts.

Fix Implemented

- Added jspdf and qrcode dependencies
- Created src/utils/pdfGenerator.ts with receipt generation logic
- Added download button to each tip row in the history table
- Receipts include all transaction details and QR code linking to Stellar Explorer for verification
- Receipt Contents

## Receipt ID, date, amount, recipient, sender, status, memo
- Transaction hash (when available)
- QR code linking to transaction on Stellar Explorer
- Generation timestamp

## Testing Performed

- Code review for TypeScript correctness
- Pattern consistency with existing export utilities
- Dependencies installed successfully