### PR TITLE
feat(widgets): add embeddable tip widgets

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -1,0 +1,88 @@
+/**
+ * Stellar Tip Jar — Standalone Widget Script
+ *
+ * Usage:
+ *   <div
+ *     data-stellar-tip
+ *     data-username="alice"
+ *     data-type="button"           <!-- "button" | "card" (default: "button") -->
+ *     data-label="Tip Me ⭐"
+ *     data-color="#0f6c7b"
+ *     data-size="md"               <!-- "sm" | "md" | "lg" -->
+ *     data-compact="false"
+ *     data-show-message="true"
+ *     data-asset="XLM"
+ *   ></div>
+ *   <script src="https://your-domain.com/widget.js" async></script>
+ */
+(function () {
+  "use strict";
+
+  var BASE_URL =
+    (document.currentScript && document.currentScript.src
+      ? new URL(document.currentScript.src).origin
+      : window.location.origin);
+
+  function buildIframe(el) {
+    var username = el.getAttribute("data-username") || "creator";
+    var type = el.getAttribute("data-type") || "button";
+    var label = el.getAttribute("data-label") || "Send a Tip \u2B50";
+    var color = el.getAttribute("data-color") || "#0f6c7b";
+    var size = el.getAttribute("data-size") || "md";
+    var compact = el.getAttribute("data-compact") || "false";
+    var showMessage = el.getAttribute("data-show-message") || "true";
+    var asset = el.getAttribute("data-asset") || "XLM";
+    var displayName = el.getAttribute("data-display-name") || "";
+    var bio = el.getAttribute("data-bio") || "";
+
+    var params = new URLSearchParams({
+      username: username,
+      type: type,
+      accentColor: color,
+      label: label,
+      size: size,
+      compact: compact,
+      showMessage: showMessage,
+      defaultAsset: asset,
+      displayName: displayName,
+      bio: bio,
+    });
+
+    var isButton = type === "button";
+    var sizeHeights = { sm: 40, md: 50, lg: 60 };
+    var width = isButton ? 220 : 380;
+    var height = isButton
+      ? (sizeHeights[size] || 50)
+      : compact === "true"
+      ? 220
+      : showMessage === "true"
+      ? 400
+      : 320;
+
+    var iframe = document.createElement("iframe");
+    iframe.src = BASE_URL + "/widgets/embed?" + params.toString();
+    iframe.width = String(width);
+    iframe.height = String(height);
+    iframe.frameBorder = "0";
+    iframe.scrolling = "no";
+    iframe.title = "Tip " + username + " on Stellar Tip Jar";
+    iframe.loading = "lazy";
+    iframe.style.cssText = "border:none;overflow:hidden;display:block;";
+    iframe.setAttribute("sandbox", "allow-scripts allow-forms allow-same-origin allow-popups");
+
+    el.appendChild(iframe);
+  }
+
+  function init() {
+    var targets = document.querySelectorAll("[data-stellar-tip]");
+    for (var i = 0; i < targets.length; i++) {
+      buildIframe(targets[i]);
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/src/app/widgets/embed/layout.tsx
+++ b/src/app/widgets/embed/layout.tsx
@@ -1,0 +1,7 @@
+export default function EmbedLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, padding: 0, background: "transparent" }}>{children}</body>
+    </html>
+  );
+}

--- a/src/app/widgets/embed/page.tsx
+++ b/src/app/widgets/embed/page.tsx
@@ -1,0 +1,64 @@
+import { TipButton } from "@/components/widgets/TipButton";
+import { TipCard } from "@/components/widgets/TipCard";
+
+interface EmbedPageProps {
+  searchParams: {
+    username?: string;
+    type?: string;
+    accentColor?: string;
+    label?: string;
+    size?: string;
+    showMessage?: string;
+    compact?: string;
+    defaultAsset?: string;
+    displayName?: string;
+    bio?: string;
+  };
+}
+
+export default function EmbedPage({ searchParams }: EmbedPageProps) {
+  const {
+    username = "creator",
+    type = "card",
+    accentColor = "#0f6c7b",
+    label = "Send a Tip ⭐",
+    size = "md",
+    showMessage = "true",
+    compact = "false",
+    defaultAsset = "XLM",
+    displayName,
+    bio,
+  } = searchParams;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "flex-start",
+        justifyContent: "center",
+        padding: "8px",
+        background: "transparent",
+        minHeight: "100vh",
+      }}
+    >
+      {type === "button" ? (
+        <TipButton
+          username={username}
+          label={label}
+          color={accentColor}
+          size={size as "sm" | "md" | "lg"}
+        />
+      ) : (
+        <TipCard
+          username={username}
+          displayName={displayName}
+          bio={bio}
+          accentColor={accentColor}
+          showMessage={showMessage === "true"}
+          compact={compact === "true"}
+          defaultAsset={defaultAsset}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/widgets/page.tsx
+++ b/src/app/widgets/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import { WidgetCustomizer } from "@/components/widgets/WidgetCustomizer";
+import { buildMetadata } from "@/utils/seo";
+
+export const metadata: Metadata = buildMetadata({
+  title: "Tip Widget Generator",
+  description: "Create embeddable tip widgets for your website, blog, or social profile.",
+  path: "/widgets",
+});
+
+export default function WidgetsPage() {
+  return (
+    <div className="space-y-8">
+      <div className="rounded-3xl border border-ink/10 bg-[color:var(--surface)] p-8 shadow-card sm:p-10">
+        <span className="inline-flex rounded-full bg-wave/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-wave">
+          Embeddable Widgets
+        </span>
+        <h1 className="mt-4 text-3xl font-bold text-ink sm:text-4xl">Tip Widget Generator</h1>
+        <p className="mt-3 max-w-2xl text-ink/70">
+          Customize a tip button or card, then copy the embed code to add it to your website, blog,
+          or any page that supports HTML.
+        </p>
+      </div>
+
+      <WidgetCustomizer />
+    </div>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -8,6 +8,7 @@ const navLinks = [
   { href: "/", label: "Home" },
   { href: "/explore", label: "Explore Creators" },
   { href: "/tips", label: "Send Tips" },
+  { href: "/widgets", label: "Widgets" },
 ] as const;
 
 export function Navbar() {

--- a/src/components/widgets/TipButton.tsx
+++ b/src/components/widgets/TipButton.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+
+export interface TipButtonConfig {
+  username: string;
+  label?: string;
+  color?: string;
+  textColor?: string;
+  borderRadius?: string;
+  size?: "sm" | "md" | "lg";
+}
+
+const sizeStyles = {
+  sm: "px-3 py-1.5 text-xs",
+  md: "px-4 py-2.5 text-sm",
+  lg: "px-6 py-3 text-base",
+};
+
+export function TipButton({
+  username,
+  label = "Send a Tip ⭐",
+  color = "#ff785a",
+  textColor = "#ffffff",
+  borderRadius = "12px",
+  size = "md",
+}: TipButtonConfig) {
+  const [clicked, setClicked] = useState(false);
+
+  const handleClick = () => {
+    setClicked(true);
+    const baseUrl =
+      typeof window !== "undefined"
+        ? `${window.location.protocol}//${window.location.host}`
+        : "";
+    window.open(`${baseUrl}/creator/${username}`, "_blank", "noopener,noreferrer");
+    setTimeout(() => setClicked(false), 1000);
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      aria-label={`Tip ${username} on Stellar Tip Jar`}
+      style={{
+        backgroundColor: color,
+        color: textColor,
+        borderRadius,
+        border: "none",
+        cursor: "pointer",
+        fontFamily: "inherit",
+        fontWeight: 600,
+        transition: "opacity 0.15s, transform 0.15s",
+        opacity: clicked ? 0.8 : 1,
+        transform: clicked ? "scale(0.97)" : "scale(1)",
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "6px",
+      }}
+      className={sizeStyles[size]}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/components/widgets/TipCard.tsx
+++ b/src/components/widgets/TipCard.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useState } from "react";
+import { createTipIntent } from "@/services/api";
+
+export interface TipCardConfig {
+  username: string;
+  displayName?: string;
+  bio?: string;
+  accentColor?: string;
+  showMessage?: boolean;
+  defaultAsset?: string;
+  compact?: boolean;
+}
+
+const PRESET_AMOUNTS = [1, 5, 10, 25];
+
+export function TipCard({
+  username,
+  displayName,
+  bio,
+  accentColor = "#0f6c7b",
+  showMessage = true,
+  defaultAsset = "XLM",
+  compact = false,
+}: TipCardConfig) {
+  const [amount, setAmount] = useState("5");
+  const [asset, setAsset] = useState(defaultAsset);
+  const [message, setMessage] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [statusMsg, setStatusMsg] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const parsed = parseFloat(amount);
+    if (!parsed || parsed <= 0) {
+      setStatus("error");
+      setStatusMsg("Enter a valid amount.");
+      return;
+    }
+    setStatus("loading");
+    try {
+      const intent = await createTipIntent({ username, amount, assetCode: asset });
+      setStatus("success");
+      setStatusMsg(
+        intent.checkoutUrl
+          ? `Tip created! Continue at: ${intent.checkoutUrl}`
+          : `Tip intent created. ID: ${intent.intentId}`,
+      );
+      setAmount("5");
+      setMessage("");
+    } catch (err) {
+      setStatus("error");
+      setStatusMsg(err instanceof Error ? err.message : "Something went wrong.");
+    }
+  };
+
+  const inputStyle: React.CSSProperties = {
+    width: "100%",
+    padding: "8px 12px",
+    borderRadius: "10px",
+    border: "1px solid rgba(0,0,0,0.15)",
+    fontSize: "14px",
+    fontFamily: "inherit",
+    outline: "none",
+    boxSizing: "border-box",
+  };
+
+  return (
+    <div
+      role="region"
+      aria-label={`Tip ${displayName ?? username}`}
+      style={{
+        fontFamily: "system-ui, sans-serif",
+        background: "#fffdf8",
+        border: "1px solid rgba(0,0,0,0.1)",
+        borderRadius: "16px",
+        padding: compact ? "16px" : "24px",
+        maxWidth: compact ? "280px" : "360px",
+        boxShadow: "0 4px 24px rgba(0,0,0,0.08)",
+        color: "#151515",
+      }}
+    >
+      {/* Header */}
+      <div style={{ marginBottom: "16px" }}>
+        <div
+          style={{
+            display: "inline-block",
+            background: `${accentColor}18`,
+            color: accentColor,
+            borderRadius: "6px",
+            padding: "2px 8px",
+            fontSize: "11px",
+            fontWeight: 700,
+            textTransform: "uppercase",
+            letterSpacing: "0.05em",
+            marginBottom: "6px",
+          }}
+        >
+          Stellar Tip Jar
+        </div>
+        <div style={{ fontWeight: 700, fontSize: compact ? "15px" : "17px" }}>
+          {displayName ?? `@${username}`}
+        </div>
+        {bio && !compact && (
+          <div style={{ fontSize: "13px", color: "#555", marginTop: "4px", lineHeight: 1.4 }}>
+            {bio}
+          </div>
+        )}
+      </div>
+
+      <form onSubmit={handleSubmit} noValidate>
+        {/* Preset amounts */}
+        <div
+          style={{ display: "flex", gap: "6px", marginBottom: "12px", flexWrap: "wrap" }}
+          role="group"
+          aria-label="Preset tip amounts"
+        >
+          {PRESET_AMOUNTS.map((preset) => (
+            <button
+              key={preset}
+              type="button"
+              onClick={() => setAmount(String(preset))}
+              aria-pressed={amount === String(preset)}
+              style={{
+                padding: "4px 10px",
+                borderRadius: "8px",
+                border: `1.5px solid ${amount === String(preset) ? accentColor : "rgba(0,0,0,0.15)"}`,
+                background: amount === String(preset) ? `${accentColor}15` : "transparent",
+                color: amount === String(preset) ? accentColor : "#555",
+                fontSize: "13px",
+                fontWeight: 600,
+                cursor: "pointer",
+                fontFamily: "inherit",
+              }}
+            >
+              {preset} {asset}
+            </button>
+          ))}
+        </div>
+
+        {/* Amount + Asset row */}
+        <div style={{ display: "flex", gap: "8px", marginBottom: "10px" }}>
+          <input
+            type="number"
+            min="0.01"
+            step="0.01"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            placeholder="Amount"
+            aria-label="Tip amount"
+            required
+            style={{ ...inputStyle, flex: 2 }}
+          />
+          <input
+            type="text"
+            value={asset}
+            onChange={(e) => setAsset(e.target.value.toUpperCase())}
+            placeholder="XLM"
+            maxLength={12}
+            aria-label="Asset code"
+            style={{ ...inputStyle, flex: 1 }}
+          />
+        </div>
+
+        {/* Message */}
+        {showMessage && !compact && (
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Leave a message (optional)"
+            maxLength={500}
+            aria-label="Optional message"
+            rows={2}
+            style={{
+              ...inputStyle,
+              resize: "vertical",
+              marginBottom: "10px",
+              minHeight: "60px",
+            }}
+          />
+        )}
+
+        {/* Status */}
+        {status === "error" && (
+          <p
+            role="alert"
+            style={{
+              fontSize: "12px",
+              color: "#ef4444",
+              background: "#fef2f2",
+              border: "1px solid #fecaca",
+              borderRadius: "8px",
+              padding: "6px 10px",
+              marginBottom: "10px",
+            }}
+          >
+            {statusMsg}
+          </p>
+        )}
+        {status === "success" && (
+          <p
+            role="status"
+            style={{
+              fontSize: "12px",
+              color: "#16a34a",
+              background: "#f0fdf4",
+              border: "1px solid #bbf7d0",
+              borderRadius: "8px",
+              padding: "6px 10px",
+              marginBottom: "10px",
+            }}
+          >
+            {statusMsg}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={status === "loading"}
+          aria-busy={status === "loading"}
+          style={{
+            width: "100%",
+            padding: "10px",
+            borderRadius: "10px",
+            border: "none",
+            background: accentColor,
+            color: "#fff",
+            fontWeight: 700,
+            fontSize: "14px",
+            cursor: status === "loading" ? "wait" : "pointer",
+            opacity: status === "loading" ? 0.7 : 1,
+            fontFamily: "inherit",
+            transition: "opacity 0.15s",
+          }}
+        >
+          {status === "loading" ? "Sending..." : `Send Tip ⭐`}
+        </button>
+      </form>
+
+      <div style={{ marginTop: "10px", textAlign: "center", fontSize: "11px", color: "#aaa" }}>
+        Powered by{" "}
+        <a
+          href="https://stellar.org"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: accentColor }}
+        >
+          Stellar
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/components/widgets/WidgetCustomizer.tsx
+++ b/src/components/widgets/WidgetCustomizer.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useState } from "react";
+import { TipButton } from "./TipButton";
+import { TipCard } from "./TipCard";
+
+type WidgetType = "button" | "card";
+
+interface Config {
+  username: string;
+  displayName: string;
+  bio: string;
+  accentColor: string;
+  label: string;
+  size: "sm" | "md" | "lg";
+  showMessage: boolean;
+  compact: boolean;
+  defaultAsset: string;
+}
+
+const DEFAULT_CONFIG: Config = {
+  username: "alice",
+  displayName: "Alice",
+  bio: "Creator & developer building cool things.",
+  accentColor: "#0f6c7b",
+  label: "Send a Tip ⭐",
+  size: "md",
+  showMessage: true,
+  compact: false,
+  defaultAsset: "XLM",
+};
+
+function buildEmbedCode(type: WidgetType, config: Config, baseUrl: string): string {
+  const params = new URLSearchParams({
+    username: config.username,
+    type,
+    accentColor: config.accentColor,
+    label: config.label,
+    size: config.size,
+    showMessage: String(config.showMessage),
+    compact: String(config.compact),
+    defaultAsset: config.defaultAsset,
+    displayName: config.displayName,
+    bio: config.bio,
+  });
+
+  return `<iframe
+  src="${baseUrl}/widgets/embed?${params.toString()}"
+  width="${type === "button" ? "200" : "380"}"
+  height="${type === "button" ? "50" : config.compact ? "220" : "380"}"
+  frameborder="0"
+  scrolling="no"
+  style="border:none;overflow:hidden;"
+  title="Tip ${config.username} on Stellar Tip Jar"
+  loading="lazy"
+></iframe>`;
+}
+
+export function WidgetCustomizer() {
+  const [type, setType] = useState<WidgetType>("card");
+  const [config, setConfig] = useState<Config>(DEFAULT_CONFIG);
+  const [copied, setCopied] = useState(false);
+
+  const baseUrl =
+    typeof window !== "undefined" ? `${window.location.protocol}//${window.location.host}` : "";
+
+  const embedCode = buildEmbedCode(type, config, baseUrl);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(embedCode);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const set = <K extends keyof Config>(key: K, value: Config[K]) =>
+    setConfig((prev) => ({ ...prev, [key]: value }));
+
+  const labelStyle = "block text-sm font-medium text-ink mb-1";
+  const inputStyle =
+    "w-full rounded-xl border border-ink/20 bg-white px-3 py-2 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-wave/30";
+
+  return (
+    <div className="grid gap-8 lg:grid-cols-2">
+      {/* Controls */}
+      <div className="space-y-5 rounded-2xl border border-ink/10 bg-[color:var(--surface)] p-6 shadow-card">
+        <h2 className="text-lg font-semibold text-ink">Customize Widget</h2>
+
+        {/* Widget type */}
+        <div>
+          <span className={labelStyle}>Widget Type</span>
+          <div className="flex gap-2">
+            {(["button", "card"] as WidgetType[]).map((t) => (
+              <button
+                key={t}
+                type="button"
+                onClick={() => setType(t)}
+                aria-pressed={type === t}
+                className={`rounded-xl border px-4 py-2 text-sm font-semibold capitalize transition-colors ${
+                  type === t
+                    ? "border-wave bg-wave/10 text-wave"
+                    : "border-ink/20 text-ink/60 hover:border-wave/40"
+                }`}
+              >
+                {t}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Username */}
+        <label className="block">
+          <span className={labelStyle}>Creator Username</span>
+          <input
+            className={inputStyle}
+            value={config.username}
+            onChange={(e) => set("username", e.target.value)}
+            placeholder="alice"
+          />
+        </label>
+
+        {/* Display name */}
+        <label className="block">
+          <span className={labelStyle}>Display Name</span>
+          <input
+            className={inputStyle}
+            value={config.displayName}
+            onChange={(e) => set("displayName", e.target.value)}
+            placeholder="Alice"
+          />
+        </label>
+
+        {/* Bio (card only) */}
+        {type === "card" && (
+          <label className="block">
+            <span className={labelStyle}>Bio</span>
+            <input
+              className={inputStyle}
+              value={config.bio}
+              onChange={(e) => set("bio", e.target.value)}
+              placeholder="Short bio..."
+            />
+          </label>
+        )}
+
+        {/* Button label (button only) */}
+        {type === "button" && (
+          <label className="block">
+            <span className={labelStyle}>Button Label</span>
+            <input
+              className={inputStyle}
+              value={config.label}
+              onChange={(e) => set("label", e.target.value)}
+              placeholder="Send a Tip ⭐"
+            />
+          </label>
+        )}
+
+        {/* Accent color */}
+        <div>
+          <span className={labelStyle}>Accent Color</span>
+          <div className="flex items-center gap-3">
+            <input
+              type="color"
+              value={config.accentColor}
+              onChange={(e) => set("accentColor", e.target.value)}
+              className="h-9 w-14 cursor-pointer rounded-lg border border-ink/20"
+              aria-label="Pick accent color"
+            />
+            <input
+              className={`${inputStyle} flex-1`}
+              value={config.accentColor}
+              onChange={(e) => set("accentColor", e.target.value)}
+              placeholder="#0f6c7b"
+            />
+          </div>
+        </div>
+
+        {/* Default asset */}
+        <label className="block">
+          <span className={labelStyle}>Default Asset</span>
+          <input
+            className={inputStyle}
+            value={config.defaultAsset}
+            onChange={(e) => set("defaultAsset", e.target.value.toUpperCase())}
+            maxLength={12}
+            placeholder="XLM"
+          />
+        </label>
+
+        {/* Size (button only) */}
+        {type === "button" && (
+          <div>
+            <span className={labelStyle}>Size</span>
+            <div className="flex gap-2">
+              {(["sm", "md", "lg"] as Config["size"][]).map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => set("size", s)}
+                  aria-pressed={config.size === s}
+                  className={`rounded-xl border px-3 py-1.5 text-sm font-semibold uppercase transition-colors ${
+                    config.size === s
+                      ? "border-wave bg-wave/10 text-wave"
+                      : "border-ink/20 text-ink/60 hover:border-wave/40"
+                  }`}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Card options */}
+        {type === "card" && (
+          <div className="flex flex-wrap gap-4">
+            <label className="flex items-center gap-2 text-sm text-ink">
+              <input
+                type="checkbox"
+                checked={config.showMessage}
+                onChange={(e) => set("showMessage", e.target.checked)}
+                className="rounded"
+              />
+              Show message field
+            </label>
+            <label className="flex items-center gap-2 text-sm text-ink">
+              <input
+                type="checkbox"
+                checked={config.compact}
+                onChange={(e) => set("compact", e.target.checked)}
+                className="rounded"
+              />
+              Compact mode
+            </label>
+          </div>
+        )}
+      </div>
+
+      {/* Preview + embed code */}
+      <div className="space-y-6">
+        <div className="rounded-2xl border border-ink/10 bg-[color:var(--surface)] p-6 shadow-card">
+          <h2 className="mb-4 text-lg font-semibold text-ink">Preview</h2>
+          <div className="flex items-start justify-center rounded-xl bg-ink/5 p-6">
+            {type === "button" ? (
+              <TipButton
+                username={config.username}
+                label={config.label}
+                color={config.accentColor}
+                size={config.size}
+              />
+            ) : (
+              <TipCard
+                username={config.username}
+                displayName={config.displayName}
+                bio={config.bio}
+                accentColor={config.accentColor}
+                showMessage={config.showMessage}
+                compact={config.compact}
+                defaultAsset={config.defaultAsset}
+              />
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-ink/10 bg-[color:var(--surface)] p-6 shadow-card">
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-ink">Embed Code</h2>
+            <button
+              type="button"
+              onClick={handleCopy}
+              aria-label="Copy embed code to clipboard"
+              className="rounded-xl border border-ink/20 px-3 py-1.5 text-xs font-semibold text-ink/70 transition-colors hover:border-wave/40 hover:text-wave"
+            >
+              {copied ? "Copied!" : "Copy"}
+            </button>
+          </div>
+          <pre className="overflow-x-auto rounded-xl bg-ink/5 p-4 text-xs text-ink/80 whitespace-pre-wrap break-all">
+            {embedCode}
+          </pre>
+          <p className="mt-3 text-xs text-ink/50">
+            Paste this snippet anywhere on your website, blog, or README.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
closes #81 
feat(widgets): add embeddable tip widgets

Adds a fully customizable tip widget system that creators can embed on any external website, blog, or social profile.

What's new:

/widgets page with a live-preview widget customizer — pick type, colors, username, size, and more, then copy the generated embed code
TipButton — a minimal styled button that links to the creator's profile, configurable color/size/label
TipCard — a self-contained tip form with preset amounts, asset input, optional message field, and direct API submission; uses inline styles so it renders correctly anywhere
/widgets/embed iframe route — a shell-free page that renders just the widget via query params, safe for cross-origin embedding
widget.js
 — a drop-in script for non-iframe embedding using data-stellar-tip attributes; injects sandboxed iframes automatically
Added "Widgets" link to the main Navbar
Embedding options:

Iframe via the generated embed code from /widgets
Script tag + data-stellar-tip div using 
widget.js