### PR TITLE
 Redesign Modal and Dialog System

### DIFF
--- a/src/components/Modal/ModalBody.tsx
+++ b/src/components/Modal/ModalBody.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import type { ModalSectionProps } from "@/components/Modal";
+
+function joinClasses(...classes: Array<string | undefined | false>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export function ModalBody({ className, ...rest }: ModalSectionProps) {
+  return <div className={joinClasses("flex-1 overflow-y-auto px-5 py-4", className)} {...rest} />;
+}

--- a/src/components/Modal/ModalFooter.tsx
+++ b/src/components/Modal/ModalFooter.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import type { ModalSectionProps } from "@/components/Modal";
+
+function joinClasses(...classes: Array<string | undefined | false>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export function ModalFooter({ className, ...rest }: ModalSectionProps) {
+  return (
+    <div
+      className={joinClasses(
+        "flex flex-wrap items-center justify-end gap-3 border-t border-black/10 px-5 py-4 dark:border-white/10",
+        className,
+      )}
+      {...rest}
+    />
+  );
+}

--- a/src/components/Modal/ModalHeader.tsx
+++ b/src/components/Modal/ModalHeader.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import type { ButtonHTMLAttributes } from "react";
+import { useModalContext, type ModalSectionProps } from "@/components/Modal";
+
+type ModalHeaderProps = ModalSectionProps & {
+  showCloseButton?: boolean;
+  closeButtonLabel?: string;
+};
+
+function joinClasses(...classes: Array<string | undefined | false>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export function ModalHeader({
+  showCloseButton = true,
+  closeButtonLabel = "Close dialog",
+  className,
+  children,
+  ...rest
+}: ModalHeaderProps) {
+  const { onClose } = useModalContext();
+
+  return (
+    <div
+      className={joinClasses(
+        "flex items-start justify-between gap-4 border-b border-black/10 px-5 py-4 dark:border-white/10",
+        className,
+      )}
+      {...rest}
+    >
+      <div className="min-w-0 flex-1">{children}</div>
+      {showCloseButton && <ModalCloseButton onClick={onClose} aria-label={closeButtonLabel} />}
+    </div>
+  );
+}
+
+function ModalCloseButton(props: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      type="button"
+      className="rounded-lg p-2 text-black/60 transition hover:bg-black/5 hover:text-black focus:outline-none focus:ring-2 focus:ring-wave dark:text-white/60 dark:hover:bg-white/10 dark:hover:text-white"
+      {...props}
+    >
+      <span aria-hidden>✕</span>
+    </button>
+  );
+}

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import {
+  createContext,
+  type HTMLAttributes,
+  type PropsWithChildren,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+} from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { createPortal } from "react-dom";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
+
+type ModalSize = "sm" | "md" | "lg" | "xl" | "full";
+
+const sizeClasses: Record<ModalSize, string> = {
+  sm: "max-w-sm",
+  md: "max-w-md",
+  lg: "max-w-2xl",
+  xl: "max-w-4xl",
+  full: "h-[100dvh] max-h-[100dvh] max-w-none rounded-none",
+};
+
+const activeModalStack: string[] = [];
+
+const getModalDepth = (id: string) => activeModalStack.indexOf(id);
+
+const removeFromStack = (id: string) => {
+  const index = activeModalStack.indexOf(id);
+  if (index >= 0) activeModalStack.splice(index, 1);
+};
+
+const bodyScrollState = {
+  lockCount: 0,
+  previousOverflow: "",
+};
+
+type ModalContextValue = {
+  onClose: () => void;
+};
+
+const ModalContext = createContext<ModalContextValue | null>(null);
+
+function joinClasses(...classes: Array<string | undefined | false>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export type ModalProps = PropsWithChildren<{
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  size?: ModalSize;
+  closeOnBackdropClick?: boolean;
+  closeOnEscape?: boolean;
+  className?: string;
+  panelClassName?: string;
+  backdropClassName?: string;
+}>;
+
+export function Modal({
+  isOpen,
+  onClose,
+  title,
+  size = "md",
+  closeOnBackdropClick = true,
+  closeOnEscape = true,
+  className,
+  panelClassName,
+  backdropClassName,
+  children,
+}: ModalProps) {
+  const modalId = useId();
+  const panelRef = useFocusTrap<HTMLDivElement>(isOpen && activeModalStack[activeModalStack.length - 1] === modalId);
+  const [mounted, setMounted] = useState(false);
+  const [, setStackVersion] = useState(0);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      removeFromStack(modalId);
+      setStackVersion((version) => version + 1);
+      return;
+    }
+
+    activeModalStack.push(modalId);
+    setStackVersion((version) => version + 1);
+
+    return () => {
+      removeFromStack(modalId);
+      setStackVersion((version) => version + 1);
+    };
+  }, [isOpen, modalId]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    bodyScrollState.lockCount += 1;
+    if (bodyScrollState.lockCount === 1) {
+      bodyScrollState.previousOverflow = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      bodyScrollState.lockCount = Math.max(0, bodyScrollState.lockCount - 1);
+      if (bodyScrollState.lockCount === 0) {
+        document.body.style.overflow = bodyScrollState.previousOverflow;
+      }
+    };
+  }, [isOpen]);
+
+  const isTopMost = activeModalStack[activeModalStack.length - 1] === modalId;
+  const depth = Math.max(getModalDepth(modalId), 0);
+  const zIndex = 40 + depth * 10;
+
+  useEffect(() => {
+    if (!isOpen || !closeOnEscape || !isTopMost) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isOpen, closeOnEscape, isTopMost, onClose]);
+
+  const contextValue = useMemo(() => ({ onClose }), [onClose]);
+
+  if (!mounted) return null;
+
+  const content = (
+    <AnimatePresence>
+      {isOpen && (
+        <ModalContext.Provider value={contextValue}>
+          <div className={joinClasses("fixed inset-0", className)} style={{ zIndex }} aria-hidden={!isTopMost}>
+            <motion.button
+              type="button"
+              aria-label="Close modal backdrop"
+              className={joinClasses("absolute inset-0 h-full w-full bg-black/55 backdrop-blur-sm", backdropClassName)}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={() => {
+                if (closeOnBackdropClick && isTopMost) onClose();
+              }}
+            />
+
+            <div className="absolute inset-0 flex items-end justify-center p-0 sm:items-center sm:p-4">
+              <motion.div
+                ref={panelRef}
+                role="dialog"
+                aria-modal="true"
+                aria-label={title}
+                className={joinClasses(
+                  "relative flex max-h-[100dvh] w-full flex-col overflow-hidden bg-white shadow-2xl dark:bg-gray-900",
+                  "rounded-t-2xl sm:max-h-[90dvh] sm:rounded-2xl",
+                  "max-sm:h-[100dvh] max-sm:w-full max-sm:max-w-none max-sm:rounded-none",
+                  sizeClasses[size],
+                  panelClassName,
+                )}
+                initial={{ opacity: 0, y: 24, scale: 0.98 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={{ opacity: 0, y: 20, scale: 0.98 }}
+                transition={{ duration: 0.2, ease: "easeOut" }}
+                onClick={(event) => event.stopPropagation()}
+              >
+                {children}
+              </motion.div>
+            </div>
+          </div>
+        </ModalContext.Provider>
+      )}
+    </AnimatePresence>
+  );
+
+  return createPortal(content, document.body);
+}
+
+export function useModalContext() {
+  const context = useContext(ModalContext);
+  if (!context) {
+    throw new Error("Modal subcomponents must be used inside <Modal>");
+  }
+
+  return context;
+}
+
+export type ModalSectionProps = HTMLAttributes<HTMLDivElement>;

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -1,3 +1,9 @@
+"use client";
+
+import { Modal } from "@/components/Modal";
+import { ModalBody } from "@/components/Modal/ModalBody";
+import { ModalFooter } from "@/components/Modal/ModalFooter";
+import { ModalHeader } from "@/components/Modal/ModalHeader";
 import { ShareButton } from "@/components/ShareButton";
 import type { SharePlatform } from "@/utils/shareUtils";
 
@@ -10,51 +16,35 @@ type ShareModalProps = {
 };
 
 export function ShareModal({ isOpen, onClose, onShare, shareUrl, shareCounts }: ShareModalProps) {
-  if (!isOpen) return null;
-
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) onClose();
-      }}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="share-modal-title"
-    >
-      <div className="w-full max-w-md rounded-2xl bg-[color:var(--surface)] p-5 shadow-xl">
-        <div className="mb-4 flex items-start justify-between">
-          <div>
-            <h2 id="share-modal-title" className="text-lg font-semibold text-ink">
-              Share this creator
-            </h2>
-            <p className="text-sm text-ink/70">Share link: {shareUrl}</p>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="text-ink/60 transition hover:text-ink"
-            aria-label="Close share dialog"
-          >
-            ✕
-          </button>
+    <Modal isOpen={isOpen} onClose={onClose} size="md" title="Share this creator">
+      <ModalHeader>
+        <div>
+          <h2 id="share-modal-title" className="text-lg font-semibold text-ink dark:text-white">
+            Share this creator
+          </h2>
+          <p className="text-sm text-ink/70 dark:text-white/70">Share link: {shareUrl}</p>
         </div>
+      </ModalHeader>
 
-        <div className="mb-3 grid grid-cols-2 gap-2">
+      <ModalBody>
+        <div className="grid grid-cols-2 gap-2">
           <ShareButton platform="twitter" onClick={onShare} count={shareCounts.twitter} />
           <ShareButton platform="facebook" onClick={onShare} count={shareCounts.facebook} />
           <ShareButton platform="linkedin" onClick={onShare} count={shareCounts.linkedin} />
           <ShareButton platform="copy" onClick={onShare} count={shareCounts.copy} />
         </div>
+      </ModalBody>
 
+      <ModalFooter>
         <button
           type="button"
           onClick={onClose}
-          className="mt-2 w-full rounded-lg border border-ink/20 px-3 py-2 text-sm font-medium text-ink transition hover:bg-ink/10"
+          className="w-full rounded-lg border border-ink/20 px-3 py-2 text-sm font-medium text-ink transition hover:bg-ink/10 dark:border-white/20 dark:text-white dark:hover:bg-white/10"
         >
           Close
         </button>
-      </div>
-    </div>
+      </ModalFooter>
+    </Modal>
   );
 }

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+type ModalState<TData> = {
+  isOpen: boolean;
+  data: TData | null;
+};
+
+export function useModal<TData = undefined>(initialOpen = false) {
+  const [state, setState] = useState<ModalState<TData>>({
+    isOpen: initialOpen,
+    data: null,
+  });
+
+  const open = useCallback((data?: TData) => {
+    setState({ isOpen: true, data: (data ?? null) as TData | null });
+  }, []);
+
+  const close = useCallback(() => {
+    setState((previous) => ({ ...previous, isOpen: false }));
+  }, []);
+
+  const toggle = useCallback(() => {
+    setState((previous) => ({ ...previous, isOpen: !previous.isOpen }));
+  }, []);
+
+  const reset = useCallback(() => {
+    setState({ isOpen: false, data: null });
+  }, []);
+
+  return {
+    isOpen: state.isOpen,
+    data: state.data,
+    open,
+    close,
+    toggle,
+    reset,
+  };
+}


### PR DESCRIPTION
close #135 

Description
Add a reusable Modal component with Framer Motion animations, size variants (sm, md, lg, xl, full), backdrop blur, optional backdrop-close, ESC-to-close handling, portal rendering, z-index stacking, and body scroll lock (src/components/Modal/index.tsx).
Add composable section primitives ModalHeader, ModalBody, and ModalFooter for consistent markup and built-in close affordance (src/components/Modal/ModalHeader.tsx, src/components/Modal/ModalBody.tsx, src/components/Modal/ModalFooter.tsx).
Add useModal hook for ergonomic modal state management exposing open, close, toggle, and reset (src/hooks/useModal.ts).
Migrate the existing ShareModal to the new primitives to demonstrate usage and consistency (src/components/ShareModal.tsx).


Testing
Ran npm run typecheck, which failed due to pre-existing unrelated syntax errors elsewhere in the repo (e.g. src/components/Leaderboards/LeaderboardTable.tsx and src/services/api.ts), not introduced by these changes.
Ran ESLint against the new modal files with npx eslint ..., which failed due to an environment/plugin error (react/display-name rule crash) in the repository tooling rather than code introduced by this PR.