### PR TITLE
feat: implement real-time tip notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 NEXT_PUBLIC_API_URL=http://localhost:8000
 NEXT_PUBLIC_STELLAR_NETWORK=testnet
-NEXT_PUBLIC_WS_URL=http://localhost:4000
+NEXT_PUBLIC_WS_URL=ws://localhost:8000/ws
 NEXT_PUBLIC_SITE_URL=https://stellar-tipjar.app

--- a/src/contexts/WebSocketContext.tsx
+++ b/src/contexts/WebSocketContext.tsx
@@ -8,21 +8,12 @@ import React, {
   useCallback,
   ReactNode,
 } from "react";
-import toast, { Toaster } from "react-hot-toast";
 
 import { useWebSocket } from "@/hooks/useWebSocket";
 import { useNotifications, TipNotification } from "@/hooks/useNotifications";
-import {
-  playNotificationSound,
-  isSoundMuted,
-  setSoundMuted,
-} from "@/utils/soundUtils";
-
-interface TipReceivedPayload {
-  amount: string;
-  from: string;
-  memo?: string;
-}
+import { useToast } from "@/hooks/useToast";
+import { playNotificationSound, isSoundMuted, setSoundMuted } from "@/utils/soundUtils";
+import type { Tip } from "@/lib/websocket/client";
 
 interface WebSocketContextType {
   notifications: TipNotification[];
@@ -34,22 +25,15 @@ interface WebSocketContextType {
   connectionStatus: string;
 }
 
-const WebSocketContext = createContext<WebSocketContextType | undefined>(
-  undefined
-);
+const WebSocketContext = createContext<WebSocketContextType | undefined>(undefined);
 
-interface WebSocketProviderProps {
-  children: ReactNode;
-}
-
-export function WebSocketProvider({ children }: WebSocketProviderProps) {
+export function WebSocketProvider({ children }: { children: ReactNode }) {
   const wsUrl = process.env.NEXT_PUBLIC_WS_URL;
-
-  const { socketRef, status } = useWebSocket({ url: wsUrl });
+  const { clientRef, status } = useWebSocket({ url: wsUrl });
   const { notifications, unreadCount, addNotification, markAllRead, clearNotifications } =
     useNotifications();
+  const toast = useToast();
 
-  // Lazy initializer reads localStorage only on the client (avoids setState-in-effect)
   const [isMuted, setIsMuted] = useState<boolean>(() =>
     typeof window !== "undefined" ? isSoundMuted() : false
   );
@@ -61,94 +45,59 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
   // Request browser notification permission on mount
   useEffect(() => {
-    if (
-      typeof window !== "undefined" &&
-      "Notification" in window &&
-      Notification.permission === "default"
-    ) {
+    if (typeof window !== "undefined" && "Notification" in window && Notification.permission === "default") {
       Notification.requestPermission();
     }
   }, []);
 
   useEffect(() => {
-    const socket = socketRef.current;
-    if (!socket) return;
+    if (status !== "connected") return;
+    const client = clientRef.current;
+    if (!client) return;
 
-    const handleTipReceived = (tip: TipReceivedPayload) => {
-      const amount = tip.amount ?? "?";
-      const shortFrom = tip.from
-        ? `${tip.from.slice(0, 4)}…${tip.from.slice(-4)}`
-        : "Unknown";
+    const channel = "tips";
 
-      addNotification({ amount, from: tip.from ?? "", memo: tip.memo });
+    const handleTip = (tip: Tip) => {
+      const shortFrom = `${tip.sender_address.slice(0, 4)}…${tip.sender_address.slice(-4)}`;
 
-      // Native OS notification (works even when the tab is in the background)
-      if (
-        typeof window !== "undefined" &&
-        "Notification" in window &&
-        Notification.permission === "granted"
-      ) {
+      addNotification({ amount: String(tip.amount), from: tip.sender_address, memo: tip.memo });
+
+      const message = tip.memo
+        ? `💸 New tip: ${tip.amount} XLM — "${tip.memo}"`
+        : `💸 New tip: ${tip.amount} XLM from ${shortFrom}`;
+
+      toast.success(message, { duration: 6000 });
+
+      if (!isMuted) {
+        playNotificationSound();
+      }
+
+      if (typeof window !== "undefined" && "Notification" in window && Notification.permission === "granted") {
         new Notification("💸 New tip received!", {
-          body: tip.memo
-            ? `${amount} XLM – "${tip.memo}"`
-            : `${amount} XLM from ${shortFrom}`,
-          icon: "/favicon.ico",
+          body: tip.memo ? `${tip.amount} XLM — "${tip.memo}"` : `${tip.amount} XLM from ${shortFrom}`,
+          icon: "/icons/icon-192x192.png",
           tag: "tip-received",
         });
       }
-
-      toast.success(
-        tip.memo
-          ? `💸 New tip: ${amount} XLM\n"${tip.memo}"`
-          : `💸 New tip: ${amount} XLM from ${shortFrom}`,
-        {
-          duration: 6000,
-          style: {
-            background: "#1e1b4b",
-            color: "#e0e7ff",
-            border: "1px solid #4f46e5",
-            borderRadius: "12px",
-            padding: "12px 16px",
-            fontSize: "14px",
-            fontWeight: "500",
-          },
-          iconTheme: { primary: "#818cf8", secondary: "#1e1b4b" },
-        }
-      );
-
-      playNotificationSound();
     };
 
-    socket.on("tip:received", handleTipReceived);
+    client.subscribe(channel, handleTip);
     return () => {
-      socket.off("tip:received", handleTipReceived);
+      client.unsubscribe(channel, handleTip);
     };
-  }, [socketRef, addNotification]);
+  }, [status, clientRef, addNotification, toast, isMuted]);
 
   return (
     <WebSocketContext.Provider
-      value={{
-        notifications,
-        unreadCount,
-        markAllRead,
-        clearNotifications,
-        isMuted,
-        setMuted,
-        connectionStatus: status,
-      }}
+      value={{ notifications, unreadCount, markAllRead, clearNotifications, isMuted, setMuted, connectionStatus: status }}
     >
       {children}
-      <Toaster position="bottom-right" />
     </WebSocketContext.Provider>
   );
 }
 
 export function useWebSocketContext(): WebSocketContextType {
   const ctx = useContext(WebSocketContext);
-  if (!ctx) {
-    throw new Error(
-      "useWebSocketContext must be used within a WebSocketProvider"
-    );
-  }
+  if (!ctx) throw new Error("useWebSocketContext must be used within a WebSocketProvider");
   return ctx;
 }

--- a/src/hooks/useTipNotifications.ts
+++ b/src/hooks/useTipNotifications.ts
@@ -1,25 +1,40 @@
-import { useEffect } from 'react';
-import { useWebSocket } from './useWebSocket';
-import toast from 'react-hot-toast';
+"use client";
+
+import { useEffect } from "react";
+import { useWebSocket } from "./useWebSocket";
+import { useToast } from "./useToast";
+import { useNotificationPrefs } from "./useNotificationPrefs";
+import { playNotificationSound } from "@/utils/soundUtils";
+import type { Tip } from "@/lib/websocket/client";
 
 export function useTipNotifications(creatorUsername: string) {
-  const { client, isConnected } = useWebSocket();
-  
+  const { clientRef, status } = useWebSocket();
+  const toast = useToast();
+  const { settings } = useNotificationPrefs();
+
   useEffect(() => {
-    if (!client || !isConnected) return;
-    
+    if (status !== "connected") return;
+    const client = clientRef.current;
+    if (!client) return;
+
+    const inAppEnabled = settings.categories.tips.inApp;
     const channel = `creator:${creatorUsername}`;
-    
-    const handler = (tip: any) => {
-      toast.success(`New tip received: ${tip.amount} XLM`, {
-        description: `From ${tip.sender_address.slice(0, 8)}...`,
-      });
+
+    const handler = (tip: Tip) => {
+      if (!inAppEnabled) return;
+
+      const shortFrom = `${tip.sender_address.slice(0, 4)}…${tip.sender_address.slice(-4)}`;
+      const message = tip.memo
+        ? `💸 ${tip.amount} XLM — "${tip.memo}"`
+        : `💸 ${tip.amount} XLM from ${shortFrom}`;
+
+      toast.success(message, { duration: 6000 });
+      playNotificationSound();
     };
-    
+
     client.subscribe(channel, handler);
-    
     return () => {
       client.unsubscribe(channel, handler);
     };
-  }, [client, isConnected, creatorUsername]);
+  }, [status, clientRef, creatorUsername, toast, settings.categories.tips.inApp]);
 }

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -1,27 +1,36 @@
-import { useEffect, useState } from 'react';
-import { WebSocketClient } from '@/lib/websocket/client';
+"use client";
 
-export function useWebSocket() {
-  const [client, setClient] = useState<WebSocketClient | null>(null);
-  const [isConnected, setIsConnected] = useState(false);
-  
-  useEffect(() => {
-    const wsUrl = process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:8000/ws';
-    const wsClient = new WebSocketClient(wsUrl);
-    
-    wsClient.connect()
-      .then(() => {
-        setIsConnected(true);
-        setClient(wsClient);
-      })
-      .catch(console.error);
-    
-    return () => {
-      wsClient.disconnect();
-    };
-  }, []);
-  
-  return { client, isConnected };
+import { useEffect, useRef, useState } from "react";
+import { WebSocketClient } from "@/lib/websocket/client";
+
+export type WsStatus = "connecting" | "connected" | "disconnected";
+
+interface UseWebSocketOptions {
+  url?: string;
 }
 
+export function useWebSocket(options?: UseWebSocketOptions) {
+  const url = options?.url ?? process.env.NEXT_PUBLIC_WS_URL ?? "ws://localhost:8000/ws";
+  const clientRef = useRef<WebSocketClient | null>(null);
+  const [status, setStatus] = useState<WsStatus>("disconnected");
 
+  useEffect(() => {
+    if (!url) return;
+
+    const client = new WebSocketClient(url);
+    clientRef.current = client;
+    setStatus("connecting");
+
+    client.connect()
+      .then(() => setStatus("connected"))
+      .catch(() => setStatus("disconnected"));
+
+    return () => {
+      client.disconnect();
+      clientRef.current = null;
+      setStatus("disconnected");
+    };
+  }, [url]);
+
+  return { clientRef, status };
+}


### PR DESCRIPTION
Closes #271

---

## Summary

Add real-time tip notifications using WebSocket connection with toast notifications and sound effects.

## Changes

- **`src/hooks/useWebSocket.ts`** — Rewritten to expose `clientRef` + `status` (`connecting | connected | disconnected`), handles connect/disconnect lifecycle, reads `NEXT_PUBLIC_WS_URL` from env
- **`src/contexts/WebSocketContext.tsx`** — Fixed to use `WebSocketClient.subscribe/unsubscribe` API; shows toasts via `useToast`, plays sounds via `playNotificationSound`, fires native browser `Notification` when permitted
- **`src/hooks/useTipNotifications.ts`** — Updated for per-creator page subscriptions; respects `settings.categories.tips.inApp` from `useNotificationPrefs`
- **`.env.example`** — Fixed `NEXT_PUBLIC_WS_URL` to use correct `ws://` protocol

## Features

- WebSocket client with exponential backoff reconnection (up to 5 attempts)
- Toast notifications with 6s duration
- Web Audio API sound effects (no external files needed)
- Native browser push notifications (when permission granted)
- Notification preferences support (respects user's inApp toggle)
- Mute/unmute sound persisted in localStorage