### PR TITLE
feat: implement voice commands with Web Speech API

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 
 import { InstallPrompt } from "@/components/InstallPrompt";
 import { Navbar } from "@/components/Navbar";
+import { VoiceCommandButton } from "@/components/VoiceCommandButton";
 import { PerformanceMonitor } from "@/components/PerformanceMonitor";
 import { ReactQueryProvider } from "@/components/ReactQueryProvider";
 import { SkipToContent } from "@/components/SkipToContent";
@@ -100,6 +101,7 @@ export default function RootLayout({
               <UpdatePrompt />
               <PWAInitializer />
               <ToastContainer />
+              <VoiceCommandButton className="fixed bottom-6 right-6 z-50 shadow-lg" />
               </ToastProvider>
             </WebSocketProvider>
           </ReactQueryProvider>

--- a/src/components/VoiceCommandButton.tsx
+++ b/src/components/VoiceCommandButton.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Mic, MicOff } from 'lucide-react';
+import { useVoiceCommands, UseVoiceCommandsOptions } from '@/hooks/useVoiceCommands';
+
+interface VoiceCommandButtonProps extends UseVoiceCommandsOptions {
+  className?: string;
+}
+
+export function VoiceCommandButton({ className = '', ...hookOptions }: VoiceCommandButtonProps) {
+  const { isListening, isSupported, startListening, stopListening } =
+    useVoiceCommands(hookOptions);
+
+  const label = isListening ? 'Stop voice commands' : 'Start voice commands';
+
+  return (
+    <div className={`relative inline-flex ${className}`}>
+      <button
+        type="button"
+        onClick={isListening ? stopListening : startListening}
+        disabled={!isSupported}
+        aria-label={label}
+        title={isSupported ? label : 'Voice commands not supported in this browser'}
+        className={[
+          'inline-flex items-center justify-center rounded-full p-2',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500/50',
+          'transition-colors',
+          isSupported
+            ? isListening
+              ? 'bg-red-100 text-red-600 hover:bg-red-200 dark:bg-red-900/30 dark:text-red-400'
+              : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700'
+            : 'cursor-not-allowed opacity-50 bg-gray-100 text-gray-400 dark:bg-gray-800',
+        ].join(' ')}
+      >
+        {isListening ? (
+          <>
+            {/* Pulsing ring indicator */}
+            <span
+              className="absolute inset-0 rounded-full animate-ping bg-red-400 opacity-30"
+              aria-hidden="true"
+            />
+            <MicOff className="h-5 w-5 relative" aria-hidden="true" />
+          </>
+        ) : (
+          <Mic className="h-5 w-5" aria-hidden="true" />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/__tests__/useVoiceCommands.test.tsx
+++ b/src/hooks/__tests__/useVoiceCommands.test.tsx
@@ -1,0 +1,246 @@
+import { renderHook, act } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ── Router mock ──────────────────────────────────────────────────────────────
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// ── Speech Synthesis mock ────────────────────────────────────────────────────
+const mockSpeak = vi.fn();
+const mockCancel = vi.fn();
+Object.defineProperty(window, 'speechSynthesis', {
+  writable: true,
+  value: { speak: mockSpeak, cancel: mockCancel },
+});
+(global as any).SpeechSynthesisUtterance = function (text: string) {
+  (this as any).text = text;
+  (this as any).lang = '';
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+interface RecognitionInstance {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  onresult: ((e: any) => void) | null;
+  onend: (() => void) | null;
+  onerror: (() => void) | null;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  abort: ReturnType<typeof vi.fn>;
+}
+
+/** Build a minimal SpeechRecognition mock and install it on window. */
+function makeSpeechRecognitionMock(): RecognitionInstance {
+  const instance: RecognitionInstance = {
+    lang: '',
+    continuous: false,
+    interimResults: false,
+    onresult: null,
+    onend: null,
+    onerror: null,
+    start: vi.fn(),
+    stop: vi.fn(),
+    abort: vi.fn(),
+  };
+
+  // Must be a real constructor function (not an arrow fn) for `new` to work
+  function SpeechRecognitionMock(this: any) {
+    Object.assign(this, instance);
+    // Keep instance in sync so tests can inspect it
+    instance.start = this.start;
+    instance.stop = this.stop;
+    instance.abort = this.abort;
+    // Proxy property writes back to instance
+    const self = this;
+    Object.defineProperties(instance, {
+      onresult: {
+        get: () => self.onresult,
+        set: (v) => { self.onresult = v; },
+        configurable: true,
+      },
+      onend: {
+        get: () => self.onend,
+        set: (v) => { self.onend = v; },
+        configurable: true,
+      },
+      onerror: {
+        get: () => self.onerror,
+        set: (v) => { self.onerror = v; },
+        configurable: true,
+      },
+    });
+  }
+
+  (window as any).SpeechRecognition = SpeechRecognitionMock;
+  delete (window as any).webkitSpeechRecognition;
+  return instance;
+}
+
+/** Fire a fake speech result on the recognition instance. */
+function fireResult(instance: RecognitionInstance, transcript: string) {
+  const event = {
+    results: [
+      Object.assign([{ transcript, confidence: 0.9 }], { isFinal: true }),
+    ],
+    resultIndex: 0,
+  };
+  instance.onresult!(event);
+}
+
+// ── Import after mocks are set up ────────────────────────────────────────────
+import { useVoiceCommands } from '@/hooks/useVoiceCommands';
+import { VoiceCommandButton } from '@/components/VoiceCommandButton';
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('useVoiceCommands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns isSupported: false when SpeechRecognition API is unavailable', () => {
+    delete (window as any).SpeechRecognition;
+    delete (window as any).webkitSpeechRecognition;
+
+    const { result } = renderHook(() => useVoiceCommands());
+    expect(result.current.isSupported).toBe(false);
+  });
+
+  it('returns isSupported: true when SpeechRecognition API is available', () => {
+    makeSpeechRecognitionMock();
+    const { result } = renderHook(() => useVoiceCommands());
+    expect(result.current.isSupported).toBe(true);
+  });
+
+  it('navigates to / for "go home" command', () => {
+    const recognition = makeSpeechRecognitionMock();
+    const { result } = renderHook(() => useVoiceCommands());
+
+    act(() => result.current.startListening());
+    act(() => fireResult(recognition, 'go home'));
+
+    expect(mockPush).toHaveBeenCalledWith('/');
+  });
+
+  it('navigates to / for "navigate home" command', () => {
+    const recognition = makeSpeechRecognitionMock();
+    const { result } = renderHook(() => useVoiceCommands());
+
+    act(() => result.current.startListening());
+    act(() => fireResult(recognition, 'navigate home'));
+
+    expect(mockPush).toHaveBeenCalledWith('/');
+  });
+
+  it('parses amount correctly from "tip 10" transcript', () => {
+    const recognition = makeSpeechRecognitionMock();
+    const onTip = vi.fn();
+    const { result } = renderHook(() => useVoiceCommands({ onTip }));
+
+    act(() => result.current.startListening());
+    act(() => fireResult(recognition, 'tip 10'));
+
+    expect(onTip).toHaveBeenCalledWith(10);
+  });
+
+  it('calls onTip without amount for "send tip" transcript', () => {
+    const recognition = makeSpeechRecognitionMock();
+    const onTip = vi.fn();
+    const { result } = renderHook(() => useVoiceCommands({ onTip }));
+
+    act(() => result.current.startListening());
+    act(() => fireResult(recognition, 'send tip'));
+
+    expect(onTip).toHaveBeenCalledWith(undefined);
+  });
+
+  it('navigates to /tips when no onTip callback provided and "send tip" heard', () => {
+    const recognition = makeSpeechRecognitionMock();
+    const { result } = renderHook(() => useVoiceCommands());
+
+    act(() => result.current.startListening());
+    act(() => fireResult(recognition, 'send tip'));
+
+    expect(mockPush).toHaveBeenCalledWith('/tips');
+  });
+
+  it('does not throw or navigate for unrecognized command', () => {
+    const recognition = makeSpeechRecognitionMock();
+    const { result } = renderHook(() => useVoiceCommands());
+
+    act(() => result.current.startListening());
+    expect(() => act(() => fireResult(recognition, 'do something random'))).not.toThrow();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('speaks "Command not recognized" for unrecognized command', () => {
+    const recognition = makeSpeechRecognitionMock();
+    const { result } = renderHook(() => useVoiceCommands());
+
+    act(() => result.current.startListening());
+    act(() => fireResult(recognition, 'do something random'));
+
+    const utteranceArg = (mockSpeak.mock.calls.at(-1)?.[0] as any)?.text;
+    expect(utteranceArg).toBe('Command not recognized');
+  });
+
+  it('aborts recognition on unmount', () => {
+    const recognition = makeSpeechRecognitionMock();
+    const { result, unmount } = renderHook(() => useVoiceCommands());
+
+    act(() => result.current.startListening());
+    unmount();
+
+    expect(recognition.abort).toHaveBeenCalled();
+  });
+});
+
+describe('VoiceCommandButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders enabled button when API is supported', () => {
+    makeSpeechRecognitionMock();
+    render(<VoiceCommandButton />);
+
+    const btn = screen.getByRole('button', { name: 'Start voice commands' });
+    expect(btn).not.toBeDisabled();
+  });
+
+  it('renders disabled button when API is unsupported', () => {
+    delete (window as any).SpeechRecognition;
+    delete (window as any).webkitSpeechRecognition;
+
+    render(<VoiceCommandButton />);
+
+    const btn = screen.getByRole('button');
+    expect(btn).toBeDisabled();
+  });
+
+  it('shows tooltip text when unsupported', () => {
+    delete (window as any).SpeechRecognition;
+    delete (window as any).webkitSpeechRecognition;
+
+    render(<VoiceCommandButton />);
+
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('title', 'Voice commands not supported in this browser');
+  });
+
+  it('changes aria-label to "Stop voice commands" while listening', async () => {
+    const recognition = makeSpeechRecognitionMock();
+    render(<VoiceCommandButton />);
+
+    const btn = screen.getByRole('button', { name: 'Start voice commands' });
+    act(() => btn.click());
+
+    expect(recognition.start).toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Stop voice commands' })).toBeTruthy();
+  });
+});

--- a/src/hooks/useVoiceCommands.ts
+++ b/src/hooks/useVoiceCommands.ts
@@ -1,154 +1,108 @@
-import { useEffect, useState, useCallback, useRef } from 'react';
-import { speechRecognition, SpeechRecognitionResult } from '@/utils/speechRecognition';
-import { keyboardShortcutsManager } from '@/utils/keyboardShortcuts';
+'use client';
 
-export interface VoiceCommandConfig {
-  enabled?: boolean;
-  language?: string;
-  commands?: Map<string, () => void>;
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+
+export interface UseVoiceCommandsOptions {
+  lang?: string;
+  onTip?: (amount?: number) => void;
 }
 
-export interface VoiceCommandState {
+export interface UseVoiceCommandsResult {
   isListening: boolean;
-  isSpeaking: boolean;
-  transcript: string;
-  confidence: number;
-  error: string | null;
+  isSupported: boolean;
+  startListening: () => void;
+  stopListening: () => void;
 }
 
-export const useVoiceCommands = (config: VoiceCommandConfig = {}) => {
-  const [state, setState] = useState<VoiceCommandState>({
-    isListening: false,
-    isSpeaking: false,
-    transcript: '',
-    confidence: 0,
-    error: null,
-  });
+function speak(text: string, lang: string) {
+  if (typeof window === 'undefined' || !window.speechSynthesis) return;
+  window.speechSynthesis.cancel();
+  const utterance = new SpeechSynthesisUtterance(text);
+  utterance.lang = lang;
+  window.speechSynthesis.speak(utterance);
+}
 
-  const commandsRef = useRef<Map<string, () => void>>(config.commands || new Map());
-  const isListeningRef = useRef(false);
+export function useVoiceCommands({
+  lang,
+  onTip,
+}: UseVoiceCommandsOptions = {}): UseVoiceCommandsResult {
+  const router = useRouter();
+  const resolvedLang =
+    lang ?? (typeof navigator !== 'undefined' ? navigator.language : 'en-US');
 
-  const handleVoiceResult = useCallback((result: SpeechRecognitionResult) => {
-    setState((prev) => ({
-      ...prev,
-      transcript: result.transcript,
-      confidence: result.confidence,
-      error: null,
-    }));
+  const SpeechRecognitionCtor =
+    typeof window !== 'undefined'
+      ? (window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition
+      : null;
 
-    if (result.isFinal) {
-      // Check if the transcript matches any registered commands
-      commandsRef.current.forEach((callback, command) => {
-        if (
-          result.transcript.includes(command.toLowerCase()) ||
-          result.transcript.startsWith(command.toLowerCase())
-        ) {
-          callback();
+  const isSupported = Boolean(SpeechRecognitionCtor);
+
+  const [isListening, setIsListening] = useState(false);
+  const recognitionRef = useRef<any>(null);
+
+  const handleResult = useCallback(
+    (event: any) => {
+      const transcript: string =
+        event.results[event.results.length - 1][0].transcript
+          .toLowerCase()
+          .trim();
+
+      if (transcript.includes('go home') || transcript.includes('navigate home')) {
+        speak('Navigating home', resolvedLang);
+        router.push('/');
+      } else if (transcript.startsWith('tip') || transcript.includes('send tip')) {
+        const match = transcript.match(/tip\s+(\d+(?:\.\d+)?)/);
+        const amount = match ? parseFloat(match[1]) : undefined;
+        const feedback = amount != null ? `Sending tip of ${amount}` : 'Sending tip';
+        speak(feedback, resolvedLang);
+        if (onTip) {
+          onTip(amount);
+        } else {
+          router.push('/tips');
         }
-      });
-    }
-  }, []);
+      } else if (transcript.startsWith('go to ')) {
+        const page = transcript.replace('go to ', '').trim();
+        speak(`Navigating to ${page}`, resolvedLang);
+        router.push(`/${page}`);
+      } else if (transcript.includes('stop listening')) {
+        speak('Stopping', resolvedLang);
+        recognitionRef.current?.stop();
+      } else {
+        speak('Command not recognized', resolvedLang);
+      }
+    },
+    [resolvedLang, router, onTip],
+  );
 
-  const handleVoiceError = useCallback((error: string) => {
-    setState((prev) => ({
-      ...prev,
-      error,
-      isListening: false,
-    }));
-    isListeningRef.current = false;
+  const stopListening = useCallback(() => {
+    recognitionRef.current?.abort();
+    setIsListening(false);
   }, []);
 
   const startListening = useCallback(() => {
-    if (!speechRecognition.isSupported()) {
-      setState((prev) => ({
-        ...prev,
-        error: 'Voice commands not supported in your browser',
-      }));
-      return;
-    }
+    if (!isSupported || !SpeechRecognitionCtor) return;
 
-    isListeningRef.current = true;
-    setState((prev) => ({
-      ...prev,
-      isListening: true,
-      error: null,
-      transcript: '',
-    }));
+    const recognition = new SpeechRecognitionCtor();
+    recognition.lang = resolvedLang;
+    recognition.continuous = false;
+    recognition.interimResults = false;
 
-    speechRecognition.startListening(
-      handleVoiceResult,
-      handleVoiceError,
-      {
-        language: config.language || 'en-US',
-        continuous: true,
-        interimResults: true,
-      }
-    );
-  }, [config.language, handleVoiceResult, handleVoiceError]);
+    recognition.onresult = handleResult;
+    recognition.onend = () => setIsListening(false);
+    recognition.onerror = () => setIsListening(false);
 
-  const stopListening = useCallback(() => {
-    isListeningRef.current = false;
-    speechRecognition.stopListening();
-    setState((prev) => ({
-      ...prev,
-      isListening: false,
-    }));
-  }, []);
+    recognitionRef.current = recognition;
+    recognition.start();
+    setIsListening(true);
+  }, [isSupported, SpeechRecognitionCtor, resolvedLang, handleResult]);
 
-  const speak = useCallback((text: string, onComplete?: () => void) => {
-    setState((prev) => ({
-      ...prev,
-      isSpeaking: true,
-    }));
-
-    speechRecognition.speak(text, () => {
-      setState((prev) => ({
-        ...prev,
-        isSpeaking: false,
-      }));
-      onComplete?.();
-    });
-  }, []);
-
-  const registerCommand = useCallback((command: string, callback: () => void) => {
-    commandsRef.current.set(command.toLowerCase(), callback);
-  }, []);
-
-  const unregisterCommand = useCallback((command: string) => {
-    commandsRef.current.delete(command.toLowerCase());
-  }, []);
-
-  // Set up keyboard shortcut for voice toggle
+  // Cleanup on unmount
   useEffect(() => {
-    if (config.enabled !== false) {
-      keyboardShortcutsManager.register({
-        key: 'v',
-        ctrl: true,
-        callback: () => {
-          if (isListeningRef.current) {
-            stopListening();
-          } else {
-            startListening();
-          }
-        },
-      });
-    }
-
     return () => {
-      keyboardShortcutsManager.unregister({
-        key: 'v',
-        ctrl: true,
-      });
+      recognitionRef.current?.abort();
     };
-  }, [startListening, stopListening, config.enabled]);
+  }, []);
 
-  return {
-    ...state,
-    startListening,
-    stopListening,
-    speak,
-    registerCommand,
-    unregisterCommand,
-    isSupported: speechRecognition.isSupported(),
-  };
-};
+  return { isListening, isSupported, startListening, stopListening };
+}


### PR DESCRIPTION
closes #365 

## Summary
  
  Implements issue #365 — voice command support using the Web Speech API.
  
  ## Changes
  
  - **`src/hooks/useVoiceCommands.ts`** — Rewrote hook to use `window.SpeechRecognition` / `window.webkitSpeechRecognition` directly. Returns
  `isSupported: false` gracefully when the API is unavailable. Exposes `{ isListening, isSupported, startListening, stopListening }`. Accepts a `lang`
  param (BCP 47, defaults to `navigator.language`). Sets `continuous = false` and `interimResults = false`. Aborts recognition on unmount.
  
  - **`src/components/VoiceCommandButton.tsx`** — New toggle button component with a pulsing mic icon while listening, disabled state with tooltip when
  unsupported, and accessible `aria-label` that switches between "Start voice commands" and "Stop voice commands".
  
  - **`src/app/layout.tsx`** — Mounts `VoiceCommandButton` as a fixed bottom-right floating button visible on every page.
  
  - **`src/hooks/__tests__/useVoiceCommands.test.tsx`** — 14 tests covering all required scenarios (see below).
  
  ## Supported Commands
  
  | Phrase | Action |
  |---|---|
  | "go home" / "navigate home" | Navigate to `/` |
  | "send tip" / "tip [amount]" | Trigger tip action; parse amount if present |
  | "go to [page]" | Navigate to `/[page]` |
  | "stop listening" | Stop recognition |
  
  Voice synthesis feedback is spoken after every command (e.g. "Navigating home", "Sending tip of 10", "Command not recognized").
  
  ## Tests
  
  All 14 new tests pass:
  - `isSupported: false` when API unavailable
  - Correct navigation for "go home" and "navigate home"
  - Tip amount correctly parsed from "tip 10"
  - `onTip` called without amount for "send tip"
  - Navigates to `/tips` when no `onTip` callback provided
  - Unrecognized command does not throw or navigate
  - Speech synthesis called with "Command not recognized"
  - Recognition aborted on unmount
  - `VoiceCommandButton` renders enabled/disabled states correctly
  - `aria-label` toggles while listening
  
  ## Testing
  
  ```bash
  npm install --legacy-peer-deps
  npx vitest run src/hooks/__tests__/useVoiceCommands.test.tsx
  