### PR TITLE
docs: add desktop and mobile app implementation 

### DIFF
--- a/docs/DESKTOP_APP.md
+++ b/docs/DESKTOP_APP.md
@@ -1,0 +1,223 @@
+# Desktop App (Electron) — #380
+
+This document outlines the architecture and implementation plan for wrapping Stellar Tip Jar in an Electron desktop application.
+
+## Overview
+
+The desktop app is a separate project that loads the Next.js web app inside an Electron `BrowserWindow`. It should live in its own repository (`stellar-tipjar-desktop`) rather than inside this Next.js repo to keep build toolchains isolated.
+
+## Repository Structure
+
+```
+stellar-tipjar-desktop/
+├── src/
+│   ├── main.ts          # Electron main process
+│   ├── preload.ts       # Preload script (context bridge)
+│   └── tray.ts          # System tray logic
+├── resources/
+│   ├── icon.png
+│   ├── icon.icns        # macOS
+│   └── icon.ico         # Windows
+├── electron-builder.yml
+├── package.json
+└── tsconfig.json
+```
+
+## Setup
+
+```bash
+npm init -y
+npm install --save-dev electron electron-builder typescript ts-node
+```
+
+`package.json` scripts:
+
+```json
+{
+  "scripts": {
+    "dev": "electron .",
+    "build": "electron-builder",
+    "build:mac": "electron-builder --mac",
+    "build:win": "electron-builder --win",
+    "build:linux": "electron-builder --linux"
+  }
+}
+```
+
+## Main Process
+
+```ts
+// src/main.ts
+import { app, BrowserWindow, Menu, Tray, nativeImage } from "electron";
+import path from "path";
+
+const WEB_URL =
+  process.env.NODE_ENV === "development"
+    ? "http://localhost:3000"
+    : "https://stellartipjar.app";
+
+let mainWindow: BrowserWindow | null = null;
+let tray: Tray | null = null;
+
+function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    minWidth: 800,
+    minHeight: 600,
+    titleBarStyle: "hiddenInset", // macOS native feel
+    webPreferences: {
+      preload: path.join(__dirname, "preload.js"),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+    icon: path.join(__dirname, "../resources/icon.png"),
+  });
+
+  mainWindow.loadURL(WEB_URL);
+}
+
+function createTray() {
+  const icon = nativeImage.createFromPath(
+    path.join(__dirname, "../resources/icon.png")
+  );
+  tray = new Tray(icon.resize({ width: 16 }));
+  tray.setToolTip("Stellar Tip Jar");
+  tray.setContextMenu(
+    Menu.buildFromTemplate([
+      { label: "Open", click: () => mainWindow?.show() },
+      { type: "separator" },
+      { label: "Quit", role: "quit" },
+    ])
+  );
+  tray.on("click", () => mainWindow?.show());
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  createTray();
+});
+
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") app.quit();
+});
+
+app.on("activate", () => {
+  if (BrowserWindow.getAllWindows().length === 0) createWindow();
+});
+```
+
+## Native Menu
+
+```ts
+// src/main.ts (continued)
+import { Menu } from "electron";
+
+const menuTemplate: Electron.MenuItemConstructorOptions[] = [
+  {
+    label: "Stellar Tip Jar",
+    submenu: [
+      { role: "about" },
+      { type: "separator" },
+      { role: "quit" },
+    ],
+  },
+  {
+    label: "View",
+    submenu: [
+      { role: "reload" },
+      { role: "toggleDevTools" },
+      { type: "separator" },
+      { role: "resetZoom" },
+      { role: "zoomIn" },
+      { role: "zoomOut" },
+      { type: "separator" },
+      { role: "togglefullscreen" },
+    ],
+  },
+];
+
+Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));
+```
+
+## System Notifications
+
+```ts
+// src/preload.ts
+import { contextBridge, ipcRenderer } from "electron";
+
+contextBridge.exposeInMainWorld("electronAPI", {
+  showNotification: (title: string, body: string) =>
+    ipcRenderer.send("show-notification", { title, body }),
+});
+```
+
+```ts
+// src/main.ts — IPC handler
+import { ipcMain, Notification } from "electron";
+
+ipcMain.on("show-notification", (_event, { title, body }) => {
+  new Notification({ title, body }).show();
+});
+```
+
+In the web app, call `window.electronAPI?.showNotification(...)` when a tip is received.
+
+## Auto-Updates
+
+Use `electron-updater` (part of `electron-builder`):
+
+```ts
+import { autoUpdater } from "electron-updater";
+
+app.whenReady().then(() => {
+  autoUpdater.checkForUpdatesAndNotify();
+});
+
+autoUpdater.on("update-available", () => {
+  mainWindow?.webContents.send("update-available");
+});
+
+autoUpdater.on("update-downloaded", () => {
+  autoUpdater.quitAndInstall();
+});
+```
+
+`electron-builder.yml`:
+
+```yaml
+appId: app.stellartipjar.desktop
+productName: Stellar Tip Jar
+publish:
+  provider: github
+  owner: Bonizozo
+  repo: stellar-tipjar-desktop
+mac:
+  category: public.app-category.finance
+  target: [dmg, zip]
+win:
+  target: [nsis, portable]
+linux:
+  target: [AppImage, deb]
+```
+
+## Security Checklist
+
+- `contextIsolation: true` — always on
+- `nodeIntegration: false` — always off
+- `sandbox: true` — enable for renderer processes
+- Validate all IPC message payloads
+- Use `will-navigate` and `new-window` events to block unexpected navigation
+- Pin Electron version in `package.json` and audit regularly
+
+## Development Workflow
+
+1. Run the Next.js dev server: `npm run dev` (in this repo)
+2. Run Electron pointing at localhost: `NODE_ENV=development electron .` (in desktop repo)
+3. For production builds, set `WEB_URL` to the deployed app URL or bundle the Next.js export
+
+## Related
+
+- [Electron docs](https://www.electronjs.org/docs/latest)
+- [electron-builder docs](https://www.electron.build)
+- PWA alternative: see `docs/PWA.md` — the existing PWA already provides installable desktop-like behavior with zero extra tooling

--- a/docs/MOBILE_APP.md
+++ b/docs/MOBILE_APP.md
@@ -1,0 +1,250 @@
+# Mobile App (React Native) — #381
+
+This document outlines the architecture and implementation plan for a native iOS and Android app using React Native.
+
+## Overview
+
+The mobile app is a separate project and should live in its own repository (`stellar-tipjar-mobile`). It shares business logic and API contracts with this web app but has its own navigation, styling, and native module setup.
+
+## Repository Structure
+
+```
+stellar-tipjar-mobile/
+├── src/
+│   ├── screens/
+│   │   ├── HomeScreen.tsx
+│   │   ├── ExploreScreen.tsx
+│   │   ├── CreatorProfileScreen.tsx
+│   │   └── TipScreen.tsx
+│   ├── navigation/
+│   │   └── RootNavigator.tsx
+│   ├── components/
+│   ├── hooks/
+│   ├── services/
+│   │   └── api.ts          # Shared API contract with web app
+│   └── utils/
+├── ios/
+├── android/
+├── app.json
+└── package.json
+```
+
+## Setup
+
+```bash
+npx @react-native-community/cli init StellarTipJar --template react-native-template-typescript
+cd StellarTipJar
+```
+
+Core dependencies:
+
+```bash
+npm install @react-navigation/native @react-navigation/native-stack
+npm install react-native-screens react-native-safe-area-context
+npm install @notifee/react-native          # Push notifications
+npm install react-native-biometrics        # Biometric auth
+npm install react-native-keychain          # Secure storage
+npm install @react-native-async-storage/async-storage
+```
+
+## Navigation
+
+```tsx
+// src/navigation/RootNavigator.tsx
+import { NavigationContainer } from "@react-navigation/native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { HomeScreen } from "@/screens/HomeScreen";
+import { ExploreScreen } from "@/screens/ExploreScreen";
+import { CreatorProfileScreen } from "@/screens/CreatorProfileScreen";
+import { TipScreen } from "@/screens/TipScreen";
+
+export type RootStackParamList = {
+  Home: undefined;
+  Explore: undefined;
+  CreatorProfile: { username: string };
+  Tip: { username: string; defaultAsset?: string };
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export function RootNavigator() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Home">
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Explore" component={ExploreScreen} />
+        <Stack.Screen
+          name="CreatorProfile"
+          component={CreatorProfileScreen}
+          options={({ route }) => ({ title: `@${route.params.username}` })}
+        />
+        <Stack.Screen name="Tip" component={TipScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+```
+
+## Deep Link Handling
+
+Configure deep links to match the web app's URL scheme:
+
+```tsx
+// src/navigation/RootNavigator.tsx
+const linking = {
+  prefixes: ["stellartipjar://", "https://stellartipjar.app"],
+  config: {
+    screens: {
+      CreatorProfile: "creator/:username",
+      Tip: "tip/:username",
+      Explore: "explore",
+    },
+  },
+};
+
+// Pass to NavigationContainer:
+<NavigationContainer linking={linking}>
+```
+
+## Push Notifications
+
+```tsx
+// src/services/notifications.ts
+import notifee, { AndroidImportance } from "@notifee/react-native";
+
+export async function requestPermission() {
+  await notifee.requestPermission();
+}
+
+export async function showTipNotification(sender: string, amount: string) {
+  const channelId = await notifee.createChannel({
+    id: "tips",
+    name: "Tip Notifications",
+    importance: AndroidImportance.HIGH,
+  });
+
+  await notifee.displayNotification({
+    title: "New Tip Received! ⭐",
+    body: `${sender} sent you ${amount} XLM`,
+    android: { channelId, pressAction: { id: "default" } },
+  });
+}
+```
+
+For remote push notifications, integrate with FCM (Android) and APNs (iOS) via your backend.
+
+## Biometric Authentication
+
+```tsx
+// src/services/biometrics.ts
+import ReactNativeBiometrics from "react-native-biometrics";
+
+const rnBiometrics = new ReactNativeBiometrics();
+
+export async function authenticateWithBiometrics(): Promise<boolean> {
+  const { available, biometryType } = await rnBiometrics.isSensorAvailable();
+  if (!available) return false;
+
+  const { success } = await rnBiometrics.simplePrompt({
+    promptMessage: `Confirm with ${biometryType}`,
+    cancelButtonText: "Use PIN",
+  });
+
+  return success;
+}
+```
+
+Require biometric confirmation before submitting a tip:
+
+```tsx
+const confirmed = await authenticateWithBiometrics();
+if (!confirmed) return;
+await submitTip(payload);
+```
+
+## Shared API Layer
+
+The `src/services/api.ts` in this mobile repo should mirror the contracts from the web app's `src/services/api.ts`. Extract shared types into a separate `@stellar-tipjar/api-types` package if both repos grow in parallel.
+
+```ts
+// src/services/api.ts
+const API_BASE = process.env.API_URL ?? "https://api.stellartipjar.app";
+
+export async function getCreatorProfile(username: string) {
+  const res = await fetch(`${API_BASE}/creators/${username}`);
+  if (!res.ok) throw new Error(`${res.status}`);
+  return res.json();
+}
+
+export async function createTipIntent(payload: {
+  username: string;
+  amount: string;
+  assetCode: string;
+}) {
+  const res = await fetch(`${API_BASE}/tips/intents`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error(`${res.status}`);
+  return res.json();
+}
+```
+
+## App Store Releases
+
+### iOS
+
+1. Open `ios/StellarTipJar.xcworkspace` in Xcode
+2. Set bundle ID: `com.stellartipjar.app`
+3. Configure signing with your Apple Developer account
+4. Archive → Distribute App → App Store Connect
+5. Submit for review via App Store Connect
+
+### Android
+
+```bash
+# Generate release keystore (one-time)
+keytool -genkey -v -keystore stellar-tipjar.keystore \
+  -alias stellar-tipjar -keyalg RSA -keysize 2048 -validity 10000
+
+# Build release APK / AAB
+cd android
+./gradlew bundleRelease
+```
+
+Upload the `.aab` to Google Play Console.
+
+### `app.json`
+
+```json
+{
+  "name": "StellarTipJar",
+  "displayName": "Stellar Tip Jar",
+  "version": "1.0.0",
+  "ios": {
+    "bundleIdentifier": "com.stellartipjar.app",
+    "buildNumber": "1"
+  },
+  "android": {
+    "package": "com.stellartipjar.app",
+    "versionCode": 1
+  }
+}
+```
+
+## Security Checklist
+
+- Store wallet keys in `react-native-keychain` (Keychain on iOS, Keystore on Android) — never in AsyncStorage
+- Require biometric confirmation for tip submission
+- Certificate pinning for API requests in production
+- Obfuscate release builds (ProGuard on Android, Bitcode on iOS)
+- Follow [OWASP Mobile Top 10](https://owasp.org/www-project-mobile-top-10/)
+
+## Related
+
+- [React Native docs](https://reactnative.dev/docs/getting-started)
+- [React Navigation docs](https://reactnavigation.org)
+- [Notifee docs](https://notifee.app)
+- Deep linking config in this web repo: `src/lib/deeplink/handler.ts`
+- PWA alternative: see `docs/PWA.md` — the existing PWA provides installable mobile-like behavior without a separate native app


### PR DESCRIPTION
closes #380 
closes #381 

Adds architecture and implementation documentation for both platform targets rather than introducing Electron or React Native directly into this Next.js repo (which would conflict with the existing build toolchain).

DESKTOP_APP.md
 covers the Electron setup — main process, BrowserWindow config, native menus, system tray, IPC-based tip notifications, electron-updater auto-updates, electron-builder packaging for mac/win/linux, and a security checklist. Recommends a separate stellar-tipjar-desktop repo that loads the deployed web app in a BrowserWindow.

MOBILE_APP.md
 covers the React Native setup — project structure, @react-navigation native stack, deep link config that mirrors this repo's URL scheme (/creator/:username, /tip/:username), push notifications via Notifee (FCM/APNs), biometric confirmation before tip submission, shared API layer, iOS/Android release steps (Xcode archive + Gradle AAB), and a security checklist. Recommends a separate stellar-tipjar-mobile repo.

Both docs reference the existing PWA (
PWA.md
) as the immediate alternative for installable desktop and mobile experiences with no extra tooling required.