### PR TITLE
feat: implement screen recording (#367)

### DIFF
--- a/src/components/ScreenRecorder.tsx
+++ b/src/components/ScreenRecorder.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useScreenRecording } from "@/hooks/useScreenRecording";
+import { Button } from "@/components/Button";
+
+const MAX_SECONDS = 300; // 5 minutes
+
+function fmt(s: number) {
+  const m = Math.floor(s / 60)
+    .toString()
+    .padStart(2, "0");
+  const sec = (s % 60).toString().padStart(2, "0");
+  return `${m}:${sec}`;
+}
+
+export function ScreenRecorder() {
+  const { state, elapsed, videoUrl, error, start, pause, resume, stop, download, discard, isSupported } =
+    useScreenRecording({ maxDurationSeconds: MAX_SECONDS, audio: true });
+
+  if (!isSupported) {
+    return (
+      <p className="text-sm text-red-500">
+        Screen recording is not supported in this browser.
+      </p>
+    );
+  }
+
+  const pct = Math.min(100, (elapsed / MAX_SECONDS) * 100);
+
+  return (
+    <div className="flex flex-col gap-4 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+      <div className="flex items-center justify-between">
+        <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100">
+          Screen Recording
+        </h2>
+        {state === "recording" && (
+          <span className="flex items-center gap-1.5 text-sm font-medium text-red-500">
+            <span className="h-2 w-2 animate-pulse rounded-full bg-red-500" aria-hidden />
+            REC
+          </span>
+        )}
+        {state === "paused" && (
+          <span className="text-sm font-medium text-yellow-500">Paused</span>
+        )}
+      </div>
+
+      {/* Timer + progress */}
+      {(state === "recording" || state === "paused") && (
+        <div className="space-y-1">
+          <div className="flex justify-between text-xs text-gray-500">
+            <span>{fmt(elapsed)}</span>
+            <span>{fmt(MAX_SECONDS)}</span>
+          </div>
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+            <div
+              className="h-full rounded-full bg-purple-600 transition-all"
+              style={{ width: `${pct}%` }}
+              role="progressbar"
+              aria-valuenow={elapsed}
+              aria-valuemax={MAX_SECONDS}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Controls */}
+      <div className="flex flex-wrap gap-2">
+        {state === "idle" && (
+          <Button onClick={start} size="sm">
+            Start Recording
+          </Button>
+        )}
+        {state === "recording" && (
+          <>
+            <Button onClick={pause} variant="secondary" size="sm">
+              Pause
+            </Button>
+            <Button onClick={stop} variant="danger" size="sm">
+              Stop
+            </Button>
+          </>
+        )}
+        {state === "paused" && (
+          <>
+            <Button onClick={resume} size="sm">
+              Resume
+            </Button>
+            <Button onClick={stop} variant="danger" size="sm">
+              Stop
+            </Button>
+          </>
+        )}
+        {state === "stopped" && videoUrl && (
+          <>
+            <Button onClick={() => download()} size="sm">
+              Download
+            </Button>
+            <Button onClick={discard} variant="secondary" size="sm">
+              Discard
+            </Button>
+          </>
+        )}
+      </div>
+
+      {/* Preview */}
+      {state === "stopped" && videoUrl && (
+        <video
+          src={videoUrl}
+          controls
+          className="w-full rounded-xl border border-gray-200 dark:border-gray-700"
+          aria-label="Recording preview"
+        />
+      )}
+
+      {error && (
+        <p className="text-sm text-red-500" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/__tests__/useScreenRecording.test.ts
+++ b/src/hooks/__tests__/useScreenRecording.test.ts
@@ -1,0 +1,84 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useScreenRecording } from "@/hooks/useScreenRecording";
+
+// Minimal MediaRecorder mock
+class MockMediaRecorder {
+  state: string = "inactive";
+  mimeType = "video/webm";
+  ondataavailable: ((e: { data: Blob }) => void) | null = null;
+  onstop: (() => void) | null = null;
+
+  start() { this.state = "recording"; }
+  pause() { this.state = "paused"; }
+  resume() { this.state = "recording"; }
+  stop() {
+    this.state = "inactive";
+    this.ondataavailable?.({ data: new Blob(["x"], { type: "video/webm" }) });
+    this.onstop?.();
+  }
+  static isTypeSupported() { return true; }
+}
+
+const mockTrack = { stop: vi.fn(), onended: null as unknown };
+const mockStream = {
+  getTracks: () => [mockTrack],
+  getVideoTracks: () => [mockTrack],
+};
+
+beforeEach(() => {
+  vi.stubGlobal("MediaRecorder", MockMediaRecorder);
+  Object.defineProperty(navigator, "mediaDevices", {
+    value: { getDisplayMedia: vi.fn().mockResolvedValue(mockStream) },
+    configurable: true,
+  });
+  vi.stubGlobal("URL", { createObjectURL: vi.fn(() => "blob:mock"), revokeObjectURL: vi.fn() });
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("useScreenRecording", () => {
+  it("starts in idle state", () => {
+    const { result } = renderHook(() => useScreenRecording());
+    expect(result.current.state).toBe("idle");
+    expect(result.current.isSupported).toBe(true);
+  });
+
+  it("transitions to recording after start()", async () => {
+    const { result } = renderHook(() => useScreenRecording());
+    await act(() => result.current.start());
+    expect(result.current.state).toBe("recording");
+  });
+
+  it("transitions to paused after pause()", async () => {
+    const { result } = renderHook(() => useScreenRecording());
+    await act(() => result.current.start());
+    act(() => result.current.pause());
+    expect(result.current.state).toBe("paused");
+  });
+
+  it("transitions back to recording after resume()", async () => {
+    const { result } = renderHook(() => useScreenRecording());
+    await act(() => result.current.start());
+    act(() => result.current.pause());
+    act(() => result.current.resume());
+    expect(result.current.state).toBe("recording");
+  });
+
+  it("transitions to stopped and sets videoUrl after stop()", async () => {
+    const { result } = renderHook(() => useScreenRecording());
+    await act(() => result.current.start());
+    act(() => result.current.stop());
+    expect(result.current.state).toBe("stopped");
+    expect(result.current.videoUrl).toBe("blob:mock");
+  });
+
+  it("resets to idle after discard()", async () => {
+    const { result } = renderHook(() => useScreenRecording());
+    await act(() => result.current.start());
+    act(() => result.current.stop());
+    act(() => result.current.discard());
+    expect(result.current.state).toBe("idle");
+    expect(result.current.videoUrl).toBeNull();
+  });
+});

--- a/src/hooks/useScreenRecording.ts
+++ b/src/hooks/useScreenRecording.ts
@@ -1,0 +1,184 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+
+export interface UseScreenRecordingOptions {
+  /** Max recording duration in seconds. Default: 300 (5 min) */
+  maxDurationSeconds?: number;
+  /** Include system/tab audio. Default: true */
+  audio?: boolean;
+}
+
+export type RecordingState = "idle" | "recording" | "paused" | "stopped";
+
+export interface UseScreenRecordingReturn {
+  state: RecordingState;
+  elapsed: number; // seconds
+  videoUrl: string | null;
+  error: string | null;
+  start: () => Promise<void>;
+  pause: () => void;
+  resume: () => void;
+  stop: () => void;
+  download: (filename?: string) => void;
+  discard: () => void;
+  isSupported: boolean;
+}
+
+export function useScreenRecording({
+  maxDurationSeconds = 300,
+  audio = true,
+}: UseScreenRecordingOptions = {}): UseScreenRecordingReturn {
+  const isSupported =
+    typeof window !== "undefined" &&
+    !!navigator.mediaDevices?.getDisplayMedia &&
+    typeof MediaRecorder !== "undefined";
+
+  const [state, setState] = useState<RecordingState>("idle");
+  const [elapsed, setElapsed] = useState(0);
+  const [videoUrl, setVideoUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const elapsedRef = useRef(0);
+
+  const clearTimer = () => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  const stopStream = () => {
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+  };
+
+  const start = useCallback(async () => {
+    if (!isSupported) {
+      setError("Screen recording is not supported in this browser.");
+      return;
+    }
+    setError(null);
+    chunksRef.current = [];
+    elapsedRef.current = 0;
+    setElapsed(0);
+
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getDisplayMedia({
+        video: { frameRate: 30 },
+        audio,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Permission denied.");
+      return;
+    }
+
+    streamRef.current = stream;
+
+    // Pick a supported MIME type
+    const mimeType = ["video/webm;codecs=vp9", "video/webm", "video/mp4"].find(
+      (m) => MediaRecorder.isTypeSupported(m)
+    );
+
+    const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+    recorderRef.current = recorder;
+
+    recorder.ondataavailable = (e) => {
+      if (e.data.size > 0) chunksRef.current.push(e.data);
+    };
+
+    recorder.onstop = () => {
+      clearTimer();
+      stopStream();
+      const blob = new Blob(chunksRef.current, {
+        type: recorder.mimeType || "video/webm",
+      });
+      setVideoUrl(URL.createObjectURL(blob));
+      setState("stopped");
+    };
+
+    recorder.start(1000); // collect chunks every second
+    setState("recording");
+
+    timerRef.current = setInterval(() => {
+      elapsedRef.current += 1;
+      setElapsed(elapsedRef.current);
+      if (elapsedRef.current >= maxDurationSeconds) {
+        recorder.stop();
+      }
+    }, 1000);
+
+    // Stop if user ends share via browser UI
+    stream.getVideoTracks()[0].onended = () => {
+      if (recorder.state !== "inactive") recorder.stop();
+    };
+  }, [isSupported, audio, maxDurationSeconds]);
+
+  const pause = useCallback(() => {
+    if (recorderRef.current?.state === "recording") {
+      recorderRef.current.pause();
+      clearTimer();
+      setState("paused");
+    }
+  }, []);
+
+  const resume = useCallback(() => {
+    if (recorderRef.current?.state === "paused") {
+      recorderRef.current.resume();
+      setState("recording");
+      timerRef.current = setInterval(() => {
+        elapsedRef.current += 1;
+        setElapsed(elapsedRef.current);
+        if (elapsedRef.current >= maxDurationSeconds) {
+          recorderRef.current?.stop();
+        }
+      }, 1000);
+    }
+  }, [maxDurationSeconds]);
+
+  const stop = useCallback(() => {
+    if (recorderRef.current && recorderRef.current.state !== "inactive") {
+      recorderRef.current.stop();
+    }
+  }, []);
+
+  const download = useCallback(
+    (filename = "recording.webm") => {
+      if (!videoUrl) return;
+      const a = document.createElement("a");
+      a.href = videoUrl;
+      a.download = filename;
+      a.click();
+    },
+    [videoUrl]
+  );
+
+  const discard = useCallback(() => {
+    stop();
+    if (videoUrl) URL.revokeObjectURL(videoUrl);
+    setVideoUrl(null);
+    setElapsed(0);
+    elapsedRef.current = 0;
+    setState("idle");
+    setError(null);
+  }, [stop, videoUrl]);
+
+  return {
+    state,
+    elapsed,
+    videoUrl,
+    error,
+    start,
+    pause,
+    resume,
+    stop,
+    download,
+    discard,
+    isSupported,
+  };
+}


### PR DESCRIPTION
Closes #367

## Changes
- `src/hooks/useScreenRecording.ts` — MediaRecorder hook with getDisplayMedia, audio capture, pause/resume, 5-min limit, download, discard
- `src/components/ScreenRecorder.tsx` — recording controls, timer progress bar, video preview, error handling
- `src/hooks/__tests__/useScreenRecording.test.ts` — 6 state-transition tests

## Usage
tsx
import { ScreenRecorder } from '@/components/ScreenRecorder';

<ScreenRecorder />
