### PR TITLE
Feat: added form validation with react hook

### DIFF
--- a/src/components/forms/CreatorForm.tsx
+++ b/src/components/forms/CreatorForm.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useForm, FormProvider } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import toast from "react-hot-toast";
+
+import { Button } from "@/components/Button";
+import { FormField } from "@/components/forms/FormField";
+import { creatorFormSchema, type CreatorFormData } from "@/lib/validation/schemas";
+
+interface CreatorFormProps {
+  onSubmit: (data: CreatorFormData) => Promise<void>;
+}
+
+export function CreatorForm({ onSubmit }: CreatorFormProps) {
+  const methods = useForm<CreatorFormData>({
+    resolver: zodResolver(creatorFormSchema),
+    mode: "onBlur",
+    reValidateMode: "onChange",
+    defaultValues: {
+      username: "",
+      wallet_address: "",
+      displayName: "",
+      bio: "",
+      email: "",
+    },
+  });
+
+  const {
+    handleSubmit,
+    formState: { isSubmitting },
+    reset,
+  } = methods;
+
+  const handleFormSubmit = async (data: CreatorFormData) => {
+    try {
+      await onSubmit(data);
+      reset();
+      toast.success("Creator profile submitted!");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Submission failed.";
+      toast.error(message);
+    }
+  };
+
+  return (
+    <FormProvider {...methods}>
+      <form
+        onSubmit={handleSubmit(handleFormSubmit)}
+        noValidate
+        aria-label="Creator registration"
+        className="space-y-2"
+      >
+        <FormField
+          name="username"
+          label="Username"
+          placeholder="alice"
+          description="3–30 characters: letters, numbers, underscores"
+        />
+
+        <FormField
+          name="wallet_address"
+          label="Stellar Wallet Address"
+          placeholder="G…"
+          description="Your 56-character Stellar public key"
+        />
+
+        <FormField
+          name="displayName"
+          label="Display Name"
+          placeholder="Alice Smith"
+          description="2–50 characters (optional)"
+        />
+
+        <FormField
+          name="bio"
+          label="Bio"
+          placeholder="Tell supporters about yourself…"
+          description="Up to 500 characters (optional)"
+        />
+
+        <FormField
+          name="email"
+          label="Email"
+          type="email"
+          placeholder="alice@example.com"
+          description="Optional — used for notifications"
+        />
+
+        <div className="pt-2">
+          <Button
+            type="submit"
+            disabled={isSubmitting}
+            aria-busy={isSubmitting}
+            aria-label={isSubmitting ? "Submitting, please wait" : "Register as creator"}
+          >
+            {isSubmitting ? "Submitting…" : "Register as Creator"}
+          </Button>
+        </div>
+      </form>
+    </FormProvider>
+  );
+}

--- a/src/components/forms/__tests__/validation.test.tsx
+++ b/src/components/forms/__tests__/validation.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { tipFormSchema, creatorFormSchema } from '@/lib/validation/schemas'
+import { TipForm } from '@/components/forms/TipForm'
+import { CreatorForm } from '@/components/forms/CreatorForm'
+
+// ── Schema unit tests ─────────────────────────────────────────────────────────
+
+describe('tipFormSchema', () => {
+  const valid = { username: 'alice', amount: '10.5', message: '' }
+
+  it('accepts valid input', () => {
+    expect(tipFormSchema.safeParse(valid).success).toBe(true)
+  })
+
+  it('rejects username shorter than 3 chars', () => {
+    const result = tipFormSchema.safeParse({ ...valid, username: 'ab' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects username with invalid characters', () => {
+    const result = tipFormSchema.safeParse({ ...valid, username: 'alice!' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects amount of zero', () => {
+    const result = tipFormSchema.safeParse({ ...valid, amount: '0' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects amount with more than 7 decimal places', () => {
+    const result = tipFormSchema.safeParse({ ...valid, amount: '1.12345678' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects message longer than 200 chars', () => {
+    const result = tipFormSchema.safeParse({ ...valid, message: 'a'.repeat(201) })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('creatorFormSchema', () => {
+  const valid = {
+    username: 'alice',
+    wallet_address: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+    displayName: 'Alice',
+    bio: '',
+    email: '',
+  }
+
+  it('accepts valid input', () => {
+    expect(creatorFormSchema.safeParse(valid).success).toBe(true)
+  })
+
+  it('rejects invalid Stellar address', () => {
+    const result = creatorFormSchema.safeParse({ ...valid, wallet_address: 'INVALID' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects address not starting with G', () => {
+    const result = creatorFormSchema.safeParse({ ...valid, wallet_address: 'B' + 'A'.repeat(55) })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects username longer than 30 chars', () => {
+    const result = creatorFormSchema.safeParse({ ...valid, username: 'a'.repeat(31) })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects invalid email', () => {
+    const result = creatorFormSchema.safeParse({ ...valid, email: 'not-an-email' })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts empty optional fields', () => {
+    const result = creatorFormSchema.safeParse({ ...valid, displayName: '', bio: '', email: '' })
+    expect(result.success).toBe(true)
+  })
+})
+
+// ── Form component tests ──────────────────────────────────────────────────────
+
+describe('TipForm', () => {
+  const user = userEvent.setup()
+
+  it('renders all fields', () => {
+    render(<TipForm />)
+    expect(screen.getByLabelText(/creator username/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/amount/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/message/i)).toBeInTheDocument()
+  })
+
+  it('shows inline error for empty username on submit', async () => {
+    render(<TipForm />)
+    await user.click(screen.getByRole('button', { name: /submit tip/i }))
+    await waitFor(() =>
+      expect(screen.getByText(/at least 3 characters/i)).toBeInTheDocument()
+    )
+  })
+
+  it('shows error for invalid amount', async () => {
+    render(<TipForm />)
+    const amountInput = screen.getByLabelText(/amount/i)
+    await user.type(amountInput, '0')
+    await user.tab()
+    await waitFor(() =>
+      expect(screen.getByText(/greater than 0/i)).toBeInTheDocument()
+    )
+  })
+})
+
+describe('CreatorForm', () => {
+  const user = userEvent.setup()
+  const noop = vi.fn().mockResolvedValue(undefined)
+
+  it('renders all fields', () => {
+    render(<CreatorForm onSubmit={noop} />)
+    expect(screen.getByLabelText(/username/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/stellar wallet address/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/bio/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
+  })
+
+  it('shows error for invalid wallet address on blur', async () => {
+    render(<CreatorForm onSubmit={noop} />)
+    const walletInput = screen.getByLabelText(/stellar wallet address/i)
+    await user.type(walletInput, 'INVALID')
+    await user.tab()
+    await waitFor(() =>
+      expect(screen.getByText(/invalid stellar address/i)).toBeInTheDocument()
+    )
+  })
+
+  it('calls onSubmit with valid data', async () => {
+    render(<CreatorForm onSubmit={noop} />)
+    await user.type(screen.getByLabelText(/username/i), 'alice')
+    await user.type(
+      screen.getByLabelText(/stellar wallet address/i),
+      'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN'
+    )
+    await user.click(screen.getByRole('button', { name: /register as creator/i }))
+    await waitFor(() => expect(noop).toHaveBeenCalledTimes(1))
+  })
+
+  it('submit button is disabled while submitting', async () => {
+    const slowSubmit = vi.fn(() => new Promise<void>((r) => setTimeout(r, 500)))
+    render(<CreatorForm onSubmit={slowSubmit} />)
+    await user.type(screen.getByLabelText(/username/i), 'alice')
+    await user.type(
+      screen.getByLabelText(/stellar wallet address/i),
+      'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN'
+    )
+    await user.click(screen.getByRole('button', { name: /register as creator/i }))
+    expect(screen.getByRole('button', { name: /submitting/i })).toBeDisabled()
+  })
+})

--- a/src/components/forms/index.ts
+++ b/src/components/forms/index.ts
@@ -3,3 +3,5 @@ export * from './Select';
 export * from './Checkbox';
 export * from './Toggle';
 export * from './FormField';
+export * from './TipForm';
+export * from './CreatorForm';

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -108,3 +108,13 @@ export const searchSchema = z.object({
 });
 
 export type SearchInput = z.infer<typeof searchSchema>;
+
+// ── Form-component aliases (matches the suggested public API) ─────────────────
+
+/** Alias for sendTipSchema — use with TipForm. */
+export const tipFormSchema = sendTipSchema;
+export type TipFormData = SendTipInput;
+
+/** Alias for createCreatorSchema — use with CreatorForm. */
+export const creatorFormSchema = createCreatorSchema;
+export type CreatorFormData = CreateCreatorInput;


### PR DESCRIPTION
Here's a summary of what was done and what already existed:             
                                                                                
  Already in place (no changes needed):                                         
                                                                                
  - react-hook-form@7.72, zod@4.3.6, @hookform/resolvers@5.2.2 — all installed  
  - src/components/forms/FormField.tsx — reusable field with useFormContext,    
  inline errors, ARIA attributes                                                
  - src/components/forms/TipForm.tsx — full tip form with zodResolver, onBlur   
   mode, submission states                                                      
  - src/lib/validation/stellar.ts — stellarAddressSchema, amountSchema          
  - src/lib/validations/tip.ts / creator.ts — standalone schemas 
  
  Closes #220 