### PR TITLE
Gesture

### DIFF
--- a/src/components/forms/CreatorForm.tsx
+++ b/src/components/forms/CreatorForm.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useForm, FormProvider } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import toast from "react-hot-toast";
+
+import { Button } from "@/components/Button";
+import { FormField } from "@/components/forms/FormField";
+import { creatorFormSchema, type CreatorFormData } from "@/lib/validation/schemas";
+
+interface CreatorFormProps {
+  onSubmit: (data: CreatorFormData) => Promise<void>;
+}
+
+export function CreatorForm({ onSubmit }: CreatorFormProps) {
+  const methods = useForm<CreatorFormData>({
+    resolver: zodResolver(creatorFormSchema),
+    mode: "onBlur",
+    reValidateMode: "onChange",
+    defaultValues: {
+      username: "",
+      wallet_address: "",
+      displayName: "",
+      bio: "",
+      email: "",
+    },
+  });
+
+  const {
+    handleSubmit,
+    formState: { isSubmitting },
+    reset,
+  } = methods;
+
+  const handleFormSubmit = async (data: CreatorFormData) => {
+    try {
+      await onSubmit(data);
+      reset();
+      toast.success("Creator profile submitted!");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Submission failed.";
+      toast.error(message);
+    }
+  };
+
+  return (
+    <FormProvider {...methods}>
+      <form
+        onSubmit={handleSubmit(handleFormSubmit)}
+        noValidate
+        aria-label="Creator registration"
+        className="space-y-2"
+      >
+        <FormField
+          name="username"
+          label="Username"
+          placeholder="alice"
+          description="3–30 characters: letters, numbers, underscores"
+        />
+
+        <FormField
+          name="wallet_address"
+          label="Stellar Wallet Address"
+          placeholder="G…"
+          description="Your 56-character Stellar public key"
+        />
+
+        <FormField
+          name="displayName"
+          label="Display Name"
+          placeholder="Alice Smith"
+          description="2–50 characters (optional)"
+        />
+
+        <FormField
+          name="bio"
+          label="Bio"
+          placeholder="Tell supporters about yourself…"
+          description="Up to 500 characters (optional)"
+        />
+
+        <FormField
+          name="email"
+          label="Email"
+          type="email"
+          placeholder="alice@example.com"
+          description="Optional — used for notifications"
+        />
+
+        <div className="pt-2">
+          <Button
+            type="submit"
+            disabled={isSubmitting}
+            aria-busy={isSubmitting}
+            aria-label={isSubmitting ? "Submitting, please wait" : "Register as creator"}
+          >
+            {isSubmitting ? "Submitting…" : "Register as Creator"}
+          </Button>
+        </div>
+      </form>
+    </FormProvider>
+  );
+}

--- a/src/components/forms/__tests__/validation.test.tsx
+++ b/src/components/forms/__tests__/validation.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { tipFormSchema, creatorFormSchema } from '@/lib/validation/schemas'
+import { TipForm } from '@/components/forms/TipForm'
+import { CreatorForm } from '@/components/forms/CreatorForm'
+
+// ── Schema unit tests ─────────────────────────────────────────────────────────
+
+describe('tipFormSchema', () => {
+  const valid = { username: 'alice', amount: '10.5', message: '' }
+
+  it('accepts valid input', () => {
+    expect(tipFormSchema.safeParse(valid).success).toBe(true)
+  })
+
+  it('rejects username shorter than 3 chars', () => {
+    const result = tipFormSchema.safeParse({ ...valid, username: 'ab' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects username with invalid characters', () => {
+    const result = tipFormSchema.safeParse({ ...valid, username: 'alice!' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects amount of zero', () => {
+    const result = tipFormSchema.safeParse({ ...valid, amount: '0' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects amount with more than 7 decimal places', () => {
+    const result = tipFormSchema.safeParse({ ...valid, amount: '1.12345678' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects message longer than 200 chars', () => {
+    const result = tipFormSchema.safeParse({ ...valid, message: 'a'.repeat(201) })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('creatorFormSchema', () => {
+  const valid = {
+    username: 'alice',
+    wallet_address: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+    displayName: 'Alice',
+    bio: '',
+    email: '',
+  }
+
+  it('accepts valid input', () => {
+    expect(creatorFormSchema.safeParse(valid).success).toBe(true)
+  })
+
+  it('rejects invalid Stellar address', () => {
+    const result = creatorFormSchema.safeParse({ ...valid, wallet_address: 'INVALID' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects address not starting with G', () => {
+    const result = creatorFormSchema.safeParse({ ...valid, wallet_address: 'B' + 'A'.repeat(55) })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects username longer than 30 chars', () => {
+    const result = creatorFormSchema.safeParse({ ...valid, username: 'a'.repeat(31) })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects invalid email', () => {
+    const result = creatorFormSchema.safeParse({ ...valid, email: 'not-an-email' })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts empty optional fields', () => {
+    const result = creatorFormSchema.safeParse({ ...valid, displayName: '', bio: '', email: '' })
+    expect(result.success).toBe(true)
+  })
+})
+
+// ── Form component tests ──────────────────────────────────────────────────────
+
+describe('TipForm', () => {
+  const user = userEvent.setup()
+
+  it('renders all fields', () => {
+    render(<TipForm />)
+    expect(screen.getByLabelText(/creator username/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/amount/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/message/i)).toBeInTheDocument()
+  })
+
+  it('shows inline error for empty username on submit', async () => {
+    render(<TipForm />)
+    await user.click(screen.getByRole('button', { name: /submit tip/i }))
+    await waitFor(() =>
+      expect(screen.getByText(/at least 3 characters/i)).toBeInTheDocument()
+    )
+  })
+
+  it('shows error for invalid amount', async () => {
+    render(<TipForm />)
+    const amountInput = screen.getByLabelText(/amount/i)
+    await user.type(amountInput, '0')
+    await user.tab()
+    await waitFor(() =>
+      expect(screen.getByText(/greater than 0/i)).toBeInTheDocument()
+    )
+  })
+})
+
+describe('CreatorForm', () => {
+  const user = userEvent.setup()
+  const noop = vi.fn().mockResolvedValue(undefined)
+
+  it('renders all fields', () => {
+    render(<CreatorForm onSubmit={noop} />)
+    expect(screen.getByLabelText(/username/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/stellar wallet address/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/bio/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
+  })
+
+  it('shows error for invalid wallet address on blur', async () => {
+    render(<CreatorForm onSubmit={noop} />)
+    const walletInput = screen.getByLabelText(/stellar wallet address/i)
+    await user.type(walletInput, 'INVALID')
+    await user.tab()
+    await waitFor(() =>
+      expect(screen.getByText(/invalid stellar address/i)).toBeInTheDocument()
+    )
+  })
+
+  it('calls onSubmit with valid data', async () => {
+    render(<CreatorForm onSubmit={noop} />)
+    await user.type(screen.getByLabelText(/username/i), 'alice')
+    await user.type(
+      screen.getByLabelText(/stellar wallet address/i),
+      'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN'
+    )
+    await user.click(screen.getByRole('button', { name: /register as creator/i }))
+    await waitFor(() => expect(noop).toHaveBeenCalledTimes(1))
+  })
+
+  it('submit button is disabled while submitting', async () => {
+    const slowSubmit = vi.fn(() => new Promise<void>((r) => setTimeout(r, 500)))
+    render(<CreatorForm onSubmit={slowSubmit} />)
+    await user.type(screen.getByLabelText(/username/i), 'alice')
+    await user.type(
+      screen.getByLabelText(/stellar wallet address/i),
+      'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN'
+    )
+    await user.click(screen.getByRole('button', { name: /register as creator/i }))
+    expect(screen.getByRole('button', { name: /submitting/i })).toBeDisabled()
+  })
+})

--- a/src/components/forms/index.ts
+++ b/src/components/forms/index.ts
@@ -3,3 +3,5 @@ export * from './Select';
 export * from './Checkbox';
 export * from './Toggle';
 export * from './FormField';
+export * from './TipForm';
+export * from './CreatorForm';

--- a/src/hooks/__tests__/useGestures.test.ts
+++ b/src/hooks/__tests__/useGestures.test.ts
@@ -1,0 +1,260 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useSwipe } from '../useSwipe'
+import { usePinchZoom } from '../usePinchZoom'
+import { useLongPress } from '../useLongPress'
+import { useGestures } from '../useGestures'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeTouch(x: number, y: number): Touch {
+  return { clientX: x, clientY: y, identifier: 0 } as Touch
+}
+
+function fireTouchEvent(el: HTMLElement, type: string, touches: Touch[], changedTouches = touches) {
+  const event = new TouchEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    touches: touches as unknown as TouchList,
+    changedTouches: changedTouches as unknown as TouchList,
+  })
+  el.dispatchEvent(event)
+}
+
+// ── useSwipe ──────────────────────────────────────────────────────────────────
+
+describe('useSwipe', () => {
+  it('calls onSwipeLeft on a left swipe', () => {
+    const onSwipeLeft = vi.fn()
+    const { result } = renderHook(() => useSwipe({ onSwipeLeft }))
+    const el = document.createElement('div')
+    act(() => result.current(el))
+
+    fireTouchEvent(el, 'touchstart', [makeTouch(200, 100)])
+    fireTouchEvent(el, 'touchend', [makeTouch(100, 100)])
+
+    expect(onSwipeLeft).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onSwipeRight on a right swipe', () => {
+    const onSwipeRight = vi.fn()
+    const { result } = renderHook(() => useSwipe({ onSwipeRight }))
+    const el = document.createElement('div')
+    act(() => result.current(el))
+
+    fireTouchEvent(el, 'touchstart', [makeTouch(100, 100)])
+    fireTouchEvent(el, 'touchend', [makeTouch(200, 100)])
+
+    expect(onSwipeRight).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onSwipeUp on an upward swipe', () => {
+    const onSwipeUp = vi.fn()
+    const { result } = renderHook(() => useSwipe({ onSwipeUp }))
+    const el = document.createElement('div')
+    act(() => result.current(el))
+
+    fireTouchEvent(el, 'touchstart', [makeTouch(100, 200)])
+    fireTouchEvent(el, 'touchend', [makeTouch(100, 100)])
+
+    expect(onSwipeUp).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onSwipeDown on a downward swipe', () => {
+    const onSwipeDown = vi.fn()
+    const { result } = renderHook(() => useSwipe({ onSwipeDown }))
+    const el = document.createElement('div')
+    act(() => result.current(el))
+
+    fireTouchEvent(el, 'touchstart', [makeTouch(100, 100)])
+    fireTouchEvent(el, 'touchend', [makeTouch(100, 200)])
+
+    expect(onSwipeDown).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire when distance is below threshold', () => {
+    const onSwipeLeft = vi.fn()
+    const { result } = renderHook(() => useSwipe({ onSwipeLeft, threshold: 50 }))
+    const el = document.createElement('div')
+    act(() => result.current(el))
+
+    fireTouchEvent(el, 'touchstart', [makeTouch(100, 100)])
+    fireTouchEvent(el, 'touchend', [makeTouch(80, 100)]) // only 20px
+
+    expect(onSwipeLeft).not.toHaveBeenCalled()
+  })
+
+  it('ignores multi-touch', () => {
+    const onSwipeLeft = vi.fn()
+    const { result } = renderHook(() => useSwipe({ onSwipeLeft }))
+    const el = document.createElement('div')
+    act(() => result.current(el))
+
+    const two = [makeTouch(200, 100), makeTouch(150, 100)]
+    fireTouchEvent(el, 'touchstart', two)
+    fireTouchEvent(el, 'touchend', two, [makeTouch(100, 100)])
+
+    expect(onSwipeLeft).not.toHaveBeenCalled()
+  })
+
+  it('removes listeners when ref is set to null', () => {
+    const onSwipeLeft = vi.fn()
+    const { result } = renderHook(() => useSwipe({ onSwipeLeft }))
+    const el = document.createElement('div')
+    act(() => result.current(el))
+    act(() => result.current(null)) // detach
+
+    fireTouchEvent(el, 'touchstart', [makeTouch(200, 100)])
+    fireTouchEvent(el, 'touchend', [makeTouch(100, 100)])
+
+    expect(onSwipeLeft).not.toHaveBeenCalled()
+  })
+})
+
+// ── usePinchZoom ──────────────────────────────────────────────────────────────
+
+describe('usePinchZoom', () => {
+  it('calls onPinchStart when two fingers touch', () => {
+    const onPinchStart = vi.fn()
+    const { result } = renderHook(() => usePinchZoom({ onPinchStart }))
+    const el = document.createElement('div')
+    act(() => result.current.ref(el))
+
+    fireTouchEvent(el, 'touchstart', [makeTouch(100, 100), makeTouch(200, 100)])
+
+    expect(onPinchStart).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onPinchChange during move', () => {
+    const onPinchChange = vi.fn()
+    const { result } = renderHook(() => usePinchZoom({ onPinchChange }))
+    const el = document.createElement('div')
+    act(() => result.current.ref(el))
+
+    // Initial distance: 100px
+    fireTouchEvent(el, 'touchstart', [makeTouch(50, 100), makeTouch(150, 100)])
+    // Spread to 200px → scale should increase
+    fireTouchEvent(el, 'touchmove', [makeTouch(0, 100), makeTouch(200, 100)])
+
+    expect(onPinchChange).toHaveBeenCalledTimes(1)
+    const [scale] = onPinchChange.mock.calls[0]
+    expect(scale).toBeGreaterThan(1)
+  })
+
+  it('calls onPinchEnd when a finger lifts', () => {
+    const onPinchEnd = vi.fn()
+    const { result } = renderHook(() => usePinchZoom({ onPinchEnd }))
+    const el = document.createElement('div')
+    act(() => result.current.ref(el))
+
+    fireTouchEvent(el, 'touchstart', [makeTouch(50, 100), makeTouch(150, 100)])
+    fireTouchEvent(el, 'touchend', [makeTouch(50, 100)], [makeTouch(150, 100)])
+
+    expect(onPinchEnd).toHaveBeenCalledTimes(1)
+  })
+
+  it('clamps scale to maxScale', () => {
+    const onPinchChange = vi.fn()
+    const { result } = renderHook(() => usePinchZoom({ onPinchChange, maxScale: 2 }))
+    const el = document.createElement('div')
+    act(() => result.current.ref(el))
+
+    // Initial 10px, spread to 1000px → raw scale 100× but clamped to 2
+    fireTouchEvent(el, 'touchstart', [makeTouch(0, 100), makeTouch(10, 100)])
+    fireTouchEvent(el, 'touchmove', [makeTouch(0, 100), makeTouch(1000, 100)])
+
+    const [scale] = onPinchChange.mock.calls[0]
+    expect(scale).toBe(2)
+  })
+
+  it('exposes commitScale', () => {
+    const { result } = renderHook(() => usePinchZoom({}))
+    expect(typeof result.current.commitScale).toBe('function')
+  })
+})
+
+// ── useLongPress ──────────────────────────────────────────────────────────────
+
+describe('useLongPress', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('fires onLongPress after the duration', () => {
+    const onLongPress = vi.fn()
+    const { result } = renderHook(() => useLongPress({ onLongPress, duration: 500 }))
+    const el = document.createElement('div')
+
+    const event = new MouseEvent('mousedown', { bubbles: true, clientX: 0, clientY: 0 })
+    act(() => result.current.onMouseDown(event as unknown as React.MouseEvent))
+    act(() => vi.advanceTimersByTime(500))
+
+    expect(onLongPress).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire if released before duration', () => {
+    const onLongPress = vi.fn()
+    const onPress = vi.fn()
+    const { result } = renderHook(() => useLongPress({ onLongPress, onPress, duration: 500 }))
+
+    const down = new MouseEvent('mousedown', { bubbles: true, clientX: 0, clientY: 0 })
+    const up = new MouseEvent('mouseup', { bubbles: true, clientX: 0, clientY: 0 })
+    act(() => result.current.onMouseDown(down as unknown as React.MouseEvent))
+    act(() => vi.advanceTimersByTime(200))
+    act(() => result.current.onMouseUp(up as unknown as React.MouseEvent))
+
+    expect(onLongPress).not.toHaveBeenCalled()
+    expect(onPress).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels if pointer moves beyond threshold', () => {
+    const onLongPress = vi.fn()
+    const { result } = renderHook(() => useLongPress({ onLongPress, duration: 500, moveThreshold: 10 }))
+
+    const down = new MouseEvent('mousedown', { bubbles: true, clientX: 0, clientY: 0 })
+    const move = new MouseEvent('mousemove', { bubbles: true, clientX: 20, clientY: 0 })
+    act(() => result.current.onMouseDown(down as unknown as React.MouseEvent))
+    act(() => result.current.onMouseMove(move as unknown as React.MouseEvent))
+    act(() => vi.advanceTimersByTime(500))
+
+    expect(onLongPress).not.toHaveBeenCalled()
+  })
+})
+
+// ── useGestures ───────────────────────────────────────────────────────────────
+
+describe('useGestures', () => {
+  it('returns ref, handlers, and commitScale', () => {
+    const { result } = renderHook(() => useGestures({}))
+    expect(typeof result.current.ref).toBe('function')
+    expect(typeof result.current.handlers).toBe('object')
+    expect(typeof result.current.commitScale).toBe('function')
+  })
+
+  it('swipe and long-press both work on the same element', () => {
+    const onSwipeLeft = vi.fn()
+    const onLongPress = vi.fn()
+    vi.useFakeTimers()
+
+    const { result } = renderHook(() =>
+      useGestures({
+        swipe: { onSwipeLeft },
+        longPress: { onLongPress, duration: 500 },
+      })
+    )
+    const el = document.createElement('div')
+    act(() => result.current.ref(el))
+
+    // swipe
+    fireTouchEvent(el, 'touchstart', [makeTouch(200, 100)])
+    fireTouchEvent(el, 'touchend', [makeTouch(100, 100)])
+    expect(onSwipeLeft).toHaveBeenCalledTimes(1)
+
+    // long-press via mouse
+    const down = new MouseEvent('mousedown', { bubbles: true, clientX: 0, clientY: 0 })
+    act(() => result.current.handlers.onMouseDown?.(down as unknown as React.MouseEvent))
+    act(() => vi.advanceTimersByTime(500))
+    expect(onLongPress).toHaveBeenCalledTimes(1)
+
+    vi.useRealTimers()
+  })
+})

--- a/src/hooks/useGestures.ts
+++ b/src/hooks/useGestures.ts
@@ -1,0 +1,50 @@
+import { useCallback, useRef } from 'react';
+import { useSwipe, type UseSwipeOptions } from './useSwipe';
+import { usePinchZoom, type UsePinchZoomOptions } from './usePinchZoom';
+import { useLongPress, type UseLongPressOptions } from './useLongPress';
+
+export interface UseGesturesOptions {
+  swipe?: UseSwipeOptions;
+  pinch?: UsePinchZoomOptions;
+  /** Omit to disable long-press. onLongPress is required when provided. */
+  longPress?: UseLongPressOptions;
+}
+
+/**
+ * Composes useSwipe, usePinchZoom, and useLongPress onto a single element.
+ *
+ * - `ref`         — callback ref for the target element (swipe + pinch)
+ * - `handlers`    — event props to spread onto the element (long-press)
+ * - `commitScale` — persist the current scale after a pinch ends
+ *
+ * @example
+ * const { ref, handlers } = useGestures({
+ *   swipe: { onSwipeLeft: goNext, onSwipeRight: goPrev },
+ *   longPress: { onLongPress: openMenu },
+ * });
+ * return <div ref={ref} {...handlers}>…</div>
+ */
+export function useGestures<T extends HTMLElement = HTMLElement>(
+  options: UseGesturesOptions = {}
+) {
+  const swipeRef = useSwipe<T>(options.swipe ?? {});
+  const { ref: pinchRef, commitScale } = usePinchZoom<T>(options.pinch ?? {});
+  // Always call — pass a no-op when longPress is not needed (rules of hooks)
+  const longPressHandlers = useLongPress(
+    options.longPress ?? { onLongPress: () => {} }
+  );
+
+  const nodeRef = useRef<T | null>(null);
+
+  const ref = useCallback((node: T | null) => {
+    nodeRef.current = node;
+    swipeRef(node);
+    pinchRef(node);
+  }, [swipeRef, pinchRef]);
+
+  return {
+    ref,
+    handlers: options.longPress ? longPressHandlers : {},
+    commitScale,
+  };
+}

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -1,0 +1,69 @@
+import { useRef, useCallback, type MouseEvent as ReactMouseEvent, type TouchEvent as ReactTouchEvent } from 'react';
+
+export interface UseLongPressOptions {
+  onLongPress: (e: TouchEvent | MouseEvent) => void;
+  onPress?: (e: TouchEvent | MouseEvent) => void;
+  /** Duration in ms before long-press fires. Default: 500 */
+  duration?: number;
+  /** Movement tolerance in px before cancelling. Default: 10 */
+  moveThreshold?: number;
+}
+
+/**
+ * Returns event handler props to spread onto any element.
+ * Works with both touch and mouse events.
+ *
+ * @example
+ * const handlers = useLongPress({ onLongPress: () => openContextMenu() });
+ * return <div {...handlers}>…</div>
+ */
+export function useLongPress(options: UseLongPressOptions) {
+  const { onLongPress, onPress, duration = 500, moveThreshold = 10 } = options;
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startPosRef = useRef<{ x: number; y: number } | null>(null);
+  const firedRef = useRef(false);
+
+  const clear = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    startPosRef.current = null;
+  }, []);
+
+  const start = useCallback((e: TouchEvent | MouseEvent) => {
+    firedRef.current = false;
+    const { clientX, clientY } = 'touches' in e ? e.touches[0] : e;
+    startPosRef.current = { x: clientX, y: clientY };
+
+    timerRef.current = setTimeout(() => {
+      firedRef.current = true;
+      onLongPress(e);
+      clear();
+    }, duration);
+  }, [onLongPress, duration, clear]);
+
+  const move = useCallback((e: TouchEvent | MouseEvent) => {
+    if (!startPosRef.current) return;
+    const { clientX, clientY } = 'touches' in e ? e.touches[0] : e;
+    const dx = Math.abs(clientX - startPosRef.current.x);
+    const dy = Math.abs(clientY - startPosRef.current.y);
+    if (dx > moveThreshold || dy > moveThreshold) clear();
+  }, [moveThreshold, clear]);
+
+  const end = useCallback((e: TouchEvent | MouseEvent) => {
+    if (!firedRef.current) onPress?.(e);
+    clear();
+  }, [onPress, clear]);
+
+  return {
+    onTouchStart: start as (e: ReactTouchEvent) => void,
+    onTouchMove: move as (e: ReactTouchEvent) => void,
+    onTouchEnd: end as (e: ReactTouchEvent) => void,
+    onMouseDown: start as (e: ReactMouseEvent) => void,
+    onMouseMove: move as (e: ReactMouseEvent) => void,
+    onMouseUp: end as (e: ReactMouseEvent) => void,
+    onMouseLeave: clear,
+  };
+}

--- a/src/hooks/usePinchZoom.ts
+++ b/src/hooks/usePinchZoom.ts
@@ -1,0 +1,82 @@
+import { useRef, useCallback } from 'react';
+
+export interface UsePinchZoomOptions {
+  onPinchStart?: (scale: number) => void;
+  onPinchChange?: (scale: number, delta: number) => void;
+  onPinchEnd?: (scale: number) => void;
+  /** Minimum scale clamp. Default: 0.5 */
+  minScale?: number;
+  /** Maximum scale clamp. Default: 4 */
+  maxScale?: number;
+}
+
+function getTouchDistance(a: Touch, b: Touch): number {
+  const dx = a.clientX - b.clientX;
+  const dy = a.clientY - b.clientY;
+  return Math.hypot(dx, dy);
+}
+
+/**
+ * Returns a callback ref that tracks two-finger pinch gestures.
+ * Reports a normalised scale value (1 = original size).
+ *
+ * @example
+ * const [scale, setScale] = useState(1);
+ * const pinchRef = usePinchZoom({ onPinchChange: (s) => setScale(s) });
+ * return <div ref={pinchRef} style={{ transform: `scale(${scale})` }}>…</div>
+ */
+export function usePinchZoom<T extends HTMLElement = HTMLElement>(
+  options: UsePinchZoomOptions = {}
+) {
+  const { onPinchStart, onPinchChange, onPinchEnd, minScale = 0.5, maxScale = 4 } = options;
+
+  const initialDistRef = useRef<number | null>(null);
+  const currentScaleRef = useRef(1);
+  const nodeRef = useRef<T | null>(null);
+
+  const handleTouchStart = useCallback((e: TouchEvent) => {
+    if (e.touches.length !== 2) return;
+    initialDistRef.current = getTouchDistance(e.touches[0], e.touches[1]);
+    onPinchStart?.(currentScaleRef.current);
+  }, [onPinchStart]);
+
+  const handleTouchMove = useCallback((e: TouchEvent) => {
+    if (e.touches.length !== 2 || initialDistRef.current === null) return;
+    e.preventDefault(); // prevent browser zoom
+
+    const dist = getTouchDistance(e.touches[0], e.touches[1]);
+    const rawScale = currentScaleRef.current * (dist / initialDistRef.current);
+    const scale = Math.min(maxScale, Math.max(minScale, rawScale));
+    const delta = scale - currentScaleRef.current;
+
+    onPinchChange?.(scale, delta);
+  }, [onPinchChange, minScale, maxScale]);
+
+  const handleTouchEnd = useCallback((e: TouchEvent) => {
+    if (e.touches.length >= 2 || initialDistRef.current === null) return;
+    onPinchEnd?.(currentScaleRef.current);
+    initialDistRef.current = null;
+  }, [onPinchEnd]);
+
+  const ref = useCallback((node: T | null) => {
+    if (nodeRef.current) {
+      nodeRef.current.removeEventListener('touchstart', handleTouchStart);
+      nodeRef.current.removeEventListener('touchmove', handleTouchMove);
+      nodeRef.current.removeEventListener('touchend', handleTouchEnd);
+    }
+    nodeRef.current = node;
+    if (node) {
+      node.addEventListener('touchstart', handleTouchStart, { passive: true });
+      // touchmove must be non-passive to call preventDefault
+      node.addEventListener('touchmove', handleTouchMove, { passive: false });
+      node.addEventListener('touchend', handleTouchEnd, { passive: true });
+    }
+  }, [handleTouchStart, handleTouchMove, handleTouchEnd]);
+
+  /** Call this to commit the current scale (e.g. on pinch end) */
+  const commitScale = useCallback((scale: number) => {
+    currentScaleRef.current = scale;
+  }, []);
+
+  return { ref, commitScale };
+}

--- a/src/hooks/useSwipe.ts
+++ b/src/hooks/useSwipe.ts
@@ -1,0 +1,74 @@
+import { useRef, useCallback } from 'react';
+
+export type SwipeDirection = 'left' | 'right' | 'up' | 'down';
+
+export interface UseSwipeOptions {
+  onSwipeLeft?: () => void;
+  onSwipeRight?: () => void;
+  onSwipeUp?: () => void;
+  onSwipeDown?: () => void;
+  /** Minimum px distance to register as a swipe. Default: 50 */
+  threshold?: number;
+  /** Maximum ms allowed for the gesture. Default: 500 */
+  timeout?: number;
+}
+
+/**
+ * Returns a callback ref to attach to any element.
+ * Fires directional callbacks on single-finger swipes.
+ * Multi-touch (pinch) is ignored so it doesn't conflict with usePinchZoom.
+ *
+ * @example
+ * const swipeRef = useSwipe({ onSwipeLeft: () => goNext() });
+ * return <div ref={swipeRef}>…</div>
+ */
+export function useSwipe<T extends HTMLElement = HTMLElement>(
+  options: UseSwipeOptions = {}
+) {
+  const { threshold = 50, timeout = 500, onSwipeLeft, onSwipeRight, onSwipeUp, onSwipeDown } = options;
+
+  const startRef = useRef<{ x: number; y: number; t: number } | null>(null);
+  const nodeRef = useRef<T | null>(null);
+
+  const handleTouchStart = useCallback((e: TouchEvent) => {
+    if (e.touches.length !== 1) return;
+    const touch = e.touches[0];
+    startRef.current = { x: touch.clientX, y: touch.clientY, t: Date.now() };
+  }, []);
+
+  const handleTouchEnd = useCallback((e: TouchEvent) => {
+    if (!startRef.current || e.changedTouches.length !== 1) return;
+    const { x, y, t } = startRef.current;
+    startRef.current = null;
+
+    if (Date.now() - t > timeout) return;
+
+    const touch = e.changedTouches[0];
+    const dx = touch.clientX - x;
+    const dy = touch.clientY - y;
+    const absDx = Math.abs(dx);
+    const absDy = Math.abs(dy);
+
+    if (Math.max(absDx, absDy) < threshold) return;
+
+    if (absDx >= absDy) {
+      dx < 0 ? onSwipeLeft?.() : onSwipeRight?.();
+    } else {
+      dy < 0 ? onSwipeUp?.() : onSwipeDown?.();
+    }
+  }, [threshold, timeout, onSwipeLeft, onSwipeRight, onSwipeUp, onSwipeDown]);
+
+  const ref = useCallback((node: T | null) => {
+    if (nodeRef.current) {
+      nodeRef.current.removeEventListener('touchstart', handleTouchStart);
+      nodeRef.current.removeEventListener('touchend', handleTouchEnd);
+    }
+    nodeRef.current = node;
+    if (node) {
+      node.addEventListener('touchstart', handleTouchStart, { passive: true });
+      node.addEventListener('touchend', handleTouchEnd, { passive: true });
+    }
+  }, [handleTouchStart, handleTouchEnd]);
+
+  return ref;
+}

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -108,3 +108,13 @@ export const searchSchema = z.object({
 });
 
 export type SearchInput = z.infer<typeof searchSchema>;
+
+// ── Form-component aliases (matches the suggested public API) ─────────────────
+
+/** Alias for sendTipSchema — use with TipForm. */
+export const tipFormSchema = sendTipSchema;
+export type TipFormData = SendTipInput;
+
+/** Alias for createCreatorSchema — use with CreatorForm. */
+export const creatorFormSchema = createCreatorSchema;
+export type CreatorFormData = CreateCreatorInput;


### PR DESCRIPTION
Here's what was built:                                                  
                                                                                
  4 new hooks, no new dependencies (all native touch/pointer events):           
                                                                                
  │ `src/hooks/useSwipe.ts`     │ Callback ref. Fires                           
  `onSwipeLeft/Right/Up/Down` on single-finger swipes. Ignores multi-touch so it
  doesn't conflict with pinch.                                                  
  │ `src/hooks/usePinchZoom.ts` │ Callback ref. Tracks two-finger distance      
  ratio, reports `scale` + `delta` to `onPinchChange`. Clamps to                
  `minScale`/`maxScale`. Returns `commitScale()` to persist the final value.    
  │ `src/hooks/useLongPress.ts` │ Returns spread-able event props               
  (`onMouseDown/Up/Move`, `onTouchStart/End/Move`). Cancels if the pointer moves
  beyond `moveThreshold`. Fires `onPress` on quick tap, `onLongPress` after     
  `duration`. │                                                                 
  │ `src/hooks/useGestures.ts`  │ Composes all three. Returns a single `ref`    
  (merges swipe + pinch callback refs) and `handlers` (long-press props).       
                                                                                
     
                                                                                
  Usage:                                                                        
                                                                                
  const { ref, handlers } = useGestures({                                       
    swipe: { onSwipeLeft: goNext, onSwipeRight: goPrev },                       
    pinch: { onPinchChange: (scale) => setScale(scale), onPinchEnd: commitScale 
  },                                                                            
    longPress: { onLongPress: openContextMenu },                                
  });                                                                           
  return <div ref={ref} {...handlers}>…</div>                                   
                                                                                
  Tests (src/hooks/__tests__/useGestures.test.ts): 16 cases covering direction  
  detection, threshold enforcement, multi-touch guard, listener cleanup, scale  
  clamping, timer-based long-press, movement cancellation, and the composed     
  hook.
  
  Closes #366                     