### PR TITLE
feat: implement tip milestone celebrations (#411)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,46 +2,47 @@ name: E2E Tests
 
 on:
   push:
-    branches: [main, feature/e2e-testing]
-  pull_request:
-    branches: [main]
+      branches: [main, feature/e2e-testing]
+        pull_request:
+            branches: [main]
 
-jobs:
-  e2e:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
+            jobs:
+              e2e:
+                  runs-on: ubuntu-latest
+                      steps:
+                            - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: package-lock.json
+                                  - uses: actions/setup-node@v6
+                                          with:
+                                                    node-version: 20
+                                                              cache: npm
+                                                                        cache-dependency-path: package-lock.json
 
-      - name: Clear npm cache
-        run: npm cache clean --force
+                                                                              - name: Clear npm cache
+                                                                                      run: npm cache clean --force
 
-      - name: Install dependencies
-        run: npm ci
+                                                                                            - name: Install dependencies
+                                                                                                    run: npm ci
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+                                                                                                          - name: Install Playwright browsers
+                                                                                                                  run: npx playwright install --with-deps
 
-      - name: Build app
-        run: npm run build
-        env:
-          NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL || 'http://localhost:3001' }}
-          NEXT_PUBLIC_STELLAR_NETWORK: testnet
+                                                                                                                        - name: Build app
+                                                                                                                                run: npm run build
+                                                                                                                                        env:
+                                                                                                                                                  NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL || 'http://localhost:3001' }}
+                                                                                                                                                            NEXT_PUBLIC_STELLAR_NETWORK: testnet
 
-      - name: Run E2E tests
-        run: npx playwright test
-        env:
-          CI: true
-          BASE_URL: http://localhost:3000
+                                                                                                                                                                  - name: Run E2E tests
+                                                                                                                                                                          run: npx playwright test
+                                                                                                                                                                                  env:
+                                                                                                                                                                                            CI: true
+                                                                                                                                                                                                      BASE_URL: http://localhost:3000
 
-      - uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 7
+                                                                                                                                                                                                            - uses: actions/upload-artifact@v7
+                                                                                                                                                                                                                    if: failure()
+                                                                                                                                                                                                                            with:
+                                                                                                                                                                                                                                      name: playwright-report
+                                                                                                                                                                                                                                                path: playwright-report/
+                                                                                                                                                                                                                                                          retention-days: 7
+                                                                                                                                                                                                                                                          

--- a/src/app/creator/[username]/page.tsx
+++ b/src/app/creator/[username]/page.tsx
@@ -1,19 +1,17 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { Glasses } from "lucide-react";
 
 import { Button } from "@/components/Button";
-import { ShareButton } from "@/components/ShareButton";
 import { ReportButton } from "@/components/ReportButton";
 import { TipForm } from "@/components/forms/TipForm";
 import { CreatorStatsDashboard } from "@/components/stats/CreatorStatsDashboard";
 import { TipComments } from "@/components/TipComments";
 import { CreatorPageRecommendations } from "@/components/CreatorPageRecommendations";
 import { EventCalendar } from "@/components/EventCalendar";
-import { TipTiers } from "@/components/TipTiers";
 import { creatorUsernameSchema } from "@/schemas/creatorSchema";
 import { getCreatorProfile } from "@/services/api";
-import { formatUsername } from "@/utils/format";
 import { generateAvatarUrl } from "@/utils/imageUtils";
 import { buildMetadata, creatorProfileJsonLd } from "@/utils/seo";
 import { TagBadge } from "@/components/TagBadge";
@@ -27,6 +25,7 @@ import { CampaignList } from "@/components/CampaignList";
 import { WalletConnectionStatus, WebSocketConnectionStatus } from "@/components/ConnectionStatus";
 import { VirtualTipTable } from "@/components/VirtualList/VirtualTipTable";
 import { useTipHistory } from "@/hooks/useTipHistory";
+import { MilestoneProgressSection } from "@/components/MilestoneProgressSection";
 
 
 interface CreatorPageProps {
@@ -170,6 +169,8 @@ function CreatorPageClient({ username, profile }: { username: string; profile: a
       </div>
 
       <PortfolioSection username={profile.username} />
+
+      <MilestoneProgressSection totalTips={profile.totalTips ?? 0} />
 
       {/* Tip history with virtual scrolling (#362) */}
       <div className="rounded-2xl border border-ink/10 bg-white/70 p-5 sm:p-6">

--- a/src/app/tips/page.tsx
+++ b/src/app/tips/page.tsx
@@ -10,6 +10,8 @@ import { ExportModal } from "@/components/ExportModal";
 import { TipForm } from "@/components/forms/TipForm";
 import { useTipHistory } from "@/hooks/useTipHistory";
 import { usePagination } from "@/hooks/usePagination";
+import { useMilestoneCelebration } from "@/hooks/useMilestoneCelebration";
+import { MilestoneCelebrationModal } from "@/components/MilestoneCelebration";
 
 export default function TipsPage() {
   const {
@@ -18,7 +20,6 @@ export default function TipsPage() {
     isLoading,
     sortField,
     sortOrder,
-    filters,
     setFilters,
     handleSort,
   } = useTipHistory();
@@ -28,6 +29,8 @@ export default function TipsPage() {
   const [showExport, setShowExport] = useState(false);
   // Use virtual table when there are enough rows to benefit from it
   const useVirtual = tips.length > 50;
+
+  const { activeMilestone, dismiss } = useMilestoneCelebration(allTips.length);
 
   const pagination = usePagination({
     totalItems: tips.length,
@@ -167,6 +170,14 @@ export default function TipsPage() {
 
       {showExport && (
         <ExportModal tips={allTips} onClose={() => setShowExport(false)} />
+      )}
+
+      {activeMilestone && (
+        <MilestoneCelebrationModal
+          milestone={activeMilestone}
+          username="tips"
+          onClose={dismiss}
+        />
       )}
     </section>
   );

--- a/src/components/MilestoneCelebration/MilestoneBadge.tsx
+++ b/src/components/MilestoneCelebration/MilestoneBadge.tsx
@@ -5,26 +5,27 @@ import { getBadgeColor } from "@/utils/milestones";
 
 interface Props {
   milestone: Milestone;
-  size?: "sm" | "md" | "lg";
-}
-
-const SIZE = { sm: "h-10 w-10 text-xl", md: "h-16 w-16 text-3xl", lg: "h-24 w-24 text-5xl" };
-const LABEL_SIZE = { sm: "text-xs", md: "text-sm", lg: "text-base" };
-
-export function MilestoneBadge({ milestone, size = "md" }: Props) {
-  const color = getBadgeColor(milestone.badge);
-  return (
-    <div className="flex flex-col items-center gap-1.5" aria-label={`${milestone.label} badge`}>
-      <div
-        className={`${SIZE[size]} flex items-center justify-center rounded-full border-4 shadow-lg`}
-        style={{ borderColor: color, boxShadow: `0 0 16px ${color}66` }}
-      >
-        <span role="img" aria-label={milestone.label}>{milestone.icon}</span>
-      </div>
-      <span className={`${LABEL_SIZE[size]} font-semibold capitalize`} style={{ color }}>
-        {milestone.badge}
-      </span>
-      <span className="text-xs font-medium text-ink/70">{milestone.label}</span>
-    </div>
-  );
-}
+    size?: "sm" | "md" | "lg";
+    }
+    
+    const SIZE = { sm: "h-10 w-10 text-xl", md: "h-16 w-16 text-3xl", lg: "h-24 w-24 text-5xl" };
+    const LABEL_SIZE = { sm: "text-xs", md: "text-sm", lg: "text-base" };
+    
+    export function MilestoneBadge({ milestone, size = "md" }: Props) {
+      const color = getBadgeColor(milestone.badge);
+        return (
+            <div className="flex flex-col items-center gap-1.5" aria-label={`${milestone.label} badge`}>
+                  <div
+                          className={`${SIZE[size]} flex items-center justify-center rounded-full border-4 shadow-lg`}
+                                  style={{ borderColor: color, boxShadow: `0 0 16px ${color}66` }}
+                                        >
+                                                <span role="img" aria-label={milestone.label}>{milestone.icon}</span>
+                                                      </div>
+                                                            <span className={`${LABEL_SIZE[size]} font-semibold capitalize`} style={{ color }}>
+                                                                    {milestone.badge}
+                                                                          </span>
+                                                                                <span className="text-xs font-medium text-ink/70">{milestone.label}</span>
+                                                                                    </div>
+                                                                                      );
+                                                                                      }
+                                                                                      "

--- a/src/components/MilestoneProgressSection.tsx
+++ b/src/components/MilestoneProgressSection.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+"use client";
+
+import { getUnlockedMilestones, MILESTONES } from "@/utils/milestones";
+import { MilestoneBadge } from "@/components/MilestoneCelebration";
+
+interface MilestoneProgressSectionProps {
+  totalTips: number;
+}
+
+/**
+ * Drop this into src/app/creator/[username]/page.tsx (or its client sub-component).
+ * Shows earned badges and a progress bar toward the next milestone.
+ *
+ * Usage:
+ *   <MilestoneProgressSection totalTips={creator.totalTips} />
+ */
+export function MilestoneProgressSection({ totalTips }: MilestoneProgressSectionProps) {
+  const unlocked = getUnlockedMilestones(totalTips);
+  const next = MILESTONES.find((m) => m.threshold > totalTips);
+  const prev = unlocked.at(-1);
+
+  const progressPct = next
+    ? Math.min(
+        100,
+        (((totalTips - (prev?.threshold ?? 0)) /
+          (next.threshold - (prev?.threshold ?? 0))) *
+          100)
+      )
+    : 100;
+
+  if (MILESTONES.length === 0) return null;
+
+  return (
+    <section aria-label="Tip milestones" className="mt-8 rounded-2xl border border-ink/10 bg-white/60 p-6 shadow-soft dark:bg-zinc-900/60">
+      <h2 className="mb-4 text-base font-semibold text-ink">Milestones</h2>
+
+      {/* Earned badges */}
+      {unlocked.length > 0 ? (
+        <div className="flex flex-wrap gap-4 mb-6">
+          {unlocked.map((m) => (
+            <MilestoneBadge key={m.id} milestone={m} size="sm" />
+          ))}
+        </div>
+      ) : (
+        <p className="mb-4 text-sm text-ink/50">No milestones yet — the first tip unlocks one! 🌱</p>
+      )}
+
+      {/* Progress toward next milestone */}
+      {next && (
+        <div>
+          <div className="mb-1.5 flex items-center justify-between text-xs text-ink/60">
+            <span>{totalTips} tips</span>
+            <span>Next: {next.icon} {next.label} ({next.threshold})</span>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-ink/10">
+            <div
+              className="h-full rounded-full bg-gradient-to-r from-primary-500 to-accent-cyan transition-all duration-700"
+              style={{ width: `${progressPct}%` }}
+              role="progressbar"
+              aria-valuenow={totalTips}
+              aria-valuemin={prev?.threshold ?? 0}
+              aria-valuemax={next.threshold}
+            />
+          </div>
+        </div>
+      )}
+
+      {!next && (
+        <p className="mt-2 text-sm font-semibold text-amber-500">🏆 All milestones reached!</p>
+      )}
+    </section>
+  );
+}

--- a/src/components/stats/CelebrationAnimation.tsx
+++ b/src/components/stats/CelebrationAnimation.tsx
@@ -1,109 +1,102 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { CheckCircle } from \"lucide-react\";  // Note: if not available, replace with SVG
+import { CheckCircle } from "lucide-react";
 
 interface CelebrationAnimationProps {
   isActive: boolean;
   onAnimationEnd?: () => void;
 }
 
+const CONFETTI_EMOJIS = ["🎉", "✨", "🎊", "⭐", "🌟", "💫"];
+
+function ConfettiParticle({ delay, x, rotation }: { delay: number; x: number; rotation: number }) {
+  const emoji = CONFETTI_EMOJIS[Math.floor(Math.random() * CONFETTI_EMOJIS.length)];
+  return (
+    <div
+      className="absolute text-lg pointer-events-none"
+      style={{
+        left: `${x}%`,
+        top: "100%",
+        animationName: "confetti-fall",
+        animationDuration: "3s",
+        animationTimingFunction: "ease-out",
+        animationFillMode: "forwards",
+        animationDelay: `${delay}ms`,
+        transform: `rotate(${rotation}deg)`,
+      }}
+    >
+      {emoji}
+    </div>
+  );
+}
+
 export function CelebrationAnimation({ isActive, onAnimationEnd }: CelebrationAnimationProps) {
   const [show, setShow] = useState(false);
 
   useEffect(() => {
-    if (isActive) {
-      setShow(true);
-      const timeout1 = setTimeout(() => {
-        // Burst confetti
-      }, 500);
-      const timeout2 = setTimeout(() => {
-        setShow(false);
-        onAnimationEnd?.();
-      }, 4000);
-      return () => {
-        clearTimeout(timeout1);
-        clearTimeout(timeout2);
-      };
-    }
+    if (!isActive) return;
+    setShow(true);
+    const timer = setTimeout(() => {
+      setShow(false);
+      onAnimationEnd?.();
+    }, 4000);
+    return () => clearTimeout(timer);
   }, [isActive, onAnimationEnd]);
 
   if (!show) return null;
 
   return (
-    <div className=\"absolute inset-0 z-20 flex items-center justify-center rounded-2xl bg-gradient-to-r from-emerald-500/20 to-blue-500/20 backdrop-blur-sm\">
-      {/* Central Icon */}
-      <div className=\"relative\">
-        <CheckCircle className=\"h-20 w-20 text-emerald-400 drop-shadow-2xl animate-bounce [animation-duration:1.5s]\" />
-        <div className=\"absolute -inset-2 rounded-full bg-emerald-400/30 blur-xl animate-ping [animation-delay:0.5s]\" />
-      </div>
+    <>
+      <style>{`
+        @keyframes confetti-fall {
+          0%   { transform: translateY(0) rotate(0deg);      opacity: 1; }
+          100% { transform: translateY(-120vh) rotate(1080deg); opacity: 0; }
+        }
+        @keyframes cel-float {
+          0%, 100% { transform: translateY(0px) rotate(0deg); }
+          50%       { transform: translateY(-20px) rotate(180deg); }
+        }
+        .cel-star { animation: cel-float 2s ease-in-out infinite; }
+        .cel-star:nth-child(even) { animation-direction: reverse; }
+      `}</style>
 
-      {/* CSS Confetti Particles */}
-      <div className=\"confetti-container absolute inset-0 pointer-events-none\">
-        {Array.from({ length: 20 }).map((_, i) => (
-          <ConfettiParticle
-            key={i}
-            delay={i * 50}
-            x={Math.random() * 100}
-            rotation={Math.random() * 360}
-          />
-        ))}
-      </div>
+      <div className="absolute inset-0 z-20 flex items-center justify-center rounded-2xl bg-gradient-to-r from-emerald-500/20 to-blue-500/20 backdrop-blur-sm">
+        {/* Central icon */}
+        <div className="relative">
+          <CheckCircle className="h-20 w-20 text-emerald-400 drop-shadow-2xl animate-bounce [animation-duration:1.5s]" />
+          <div className="absolute -inset-2 rounded-full bg-emerald-400/30 blur-xl animate-ping [animation-delay:0.5s]" />
+        </div>
 
-      {/* Floating Stars */}
-      <div className=\"stars absolute inset-0\">
-        {Array.from({ length: 8 }).map((_, i) => (
-          <div
-            key={i}
-            className=\"star absolute text-yellow-300 text-xl animate-float [animation-delay:var(--delay)] opacity-75\"
-            style={{
-              left: `${Math.random() * 80 + 10}%`,
-              top: `${Math.random() * 80 + 10}%`,
-              '--delay': `${i * 200}ms`
-            } as React.CSSProperties
-          }
-          >
-            ⭐
-          </div>
-        ))}
+        {/* Confetti */}
+        <div className="absolute inset-0 pointer-events-none overflow-hidden">
+          {Array.from({ length: 20 }).map((_, i) => (
+            <ConfettiParticle
+              key={i}
+              delay={i * 50}
+              x={Math.random() * 100}
+              rotation={Math.random() * 360}
+            />
+          ))}
+        </div>
+
+        {/* Floating stars */}
+        <div className="absolute inset-0 pointer-events-none">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="cel-star absolute text-yellow-300 text-xl opacity-75"
+              style={{
+                left: `${10 + i * 10}%`,
+                top: `${20 + (i % 3) * 25}%`,
+                animationDelay: `${i * 200}ms`,
+              }}
+            >
+              ⭐
+            </div>
+          ))}
+        </div>
       </div>
-    </div>
+    </>
   );
 }
-
-function ConfettiParticle({ delay, x, rotation }: { delay: number; x: number; rotation: number }) {
-  return (
-    <div
-      className=\"absolute text-lg [animation:confetti-fall 3s ease-out forwards] [animation-delay:var(--delay)ms]\"
-      style={{
-        left: `${x}%`,
-        '--delay': `${delay}ms` as any,
-        transform: `rotate(${rotation}deg)`
-      }}
-    >
-      <span>🎉</span><span>✨</span><span>🎊</span>[Math.random() > 0.5 ? '🎉' : '⭐']
-    </div>
-  );
-}
-
-const styles = `
-@keyframes confetti-fall {
-  0% {
-    transform: translateY(100vh) rotate(0deg);
-    opacity: 1;
-  }
-  100% {
-    transform: translateY(-20vh) rotate(1080deg);
-    opacity: 0;
-  }
-}
-@keyframes float {
-  0%, 100% { transform: translateY(0px) rotate(0deg); }
-  50% { transform: translateY(-20px) rotate(180deg); }
-}
-.stars .star:nth-child(even) { animation-direction: reverse; }
-`;
-
-// Inline styles for simplicity
-<style jsx global>{styles}</style>
-


### PR DESCRIPTION
Implement Tip Milestone Celebrations
Closes #411
What this PR does
Wires up the existing milestone infrastructure into the actual user-facing tip flow so celebrations trigger correctly when creators hit tip thresholds.
Changes

src/components/stats/CelebrationAnimation.tsx — Fixed broken JSX syntax, removed invalid <style jsx> usage, replaced inline [Math.random()] expression with proper emoji array, made confetti animation self-contained with inline <style> tag
src/app/tips/page.tsx — Integrated useMilestoneCelebration hook and rendered MilestoneCelebrationModal when a milestone is reached; modal plays sound, shows confetti, and offers social sharing
src/app/creator/[username]/page.tsx — Added MilestoneProgressSection showing earned badges and a progress bar toward the next milestone

How milestones work
useMilestoneCelebration(totalTips) watches the running tip count. When it crosses a threshold defined in utils/milestones.ts (1 / 10 / 50 / 100 / 500 / 1000), it fires once per session via a useRef Set. The modal renders over the page, plays a Web Audio chime, shows confetti via MilestoneConfetti, and offers a native share sheet via shareDeepLink.
Testing

Temporarily set totalTips to 1, 10, 50 etc. to verify each milestone triggers exactly once
Toggle system reduced-motion to verify confetti respects prefers-reduced-motion
Check sound mute/volume controls persist across page reloads via localStorage keys tipjar:soundMuted / tipjar:soundVolume