### PR TITLE
feat: implement multi-language support with next-intl

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1,28 +1,63 @@
 {
   "common": {
-    "welcome": "مرحبا بك في Stellar Tip Jar",
-    "loading": "جار التحميل...",
+    "welcome": "مرحباً بك في Stellar Tip Jar",
+    "loading": "جارٍ التحميل...",
     "error": "حدث خطأ",
     "submit": "إرسال",
-    "cancel": "إلغاء"
+    "cancel": "إلغاء",
+    "save": "حفظ",
+    "delete": "حذف",
+    "edit": "تعديل",
+    "close": "إغلاق",
+    "search": "بحث",
+    "back": "رجوع",
+    "next": "التالي",
+    "confirm": "تأكيد"
   },
   "nav": {
     "home": "الرئيسية",
-    "explore": "استكشف المبدعين",
+    "explore": "استكشاف المبدعين",
     "tips": "إرسال إكرامية",
-    "about": "حول"
+    "about": "حول",
+    "dashboard": "لوحة التحكم",
+    "settings": "الإعدادات",
+    "profile": "الملف الشخصي"
   },
   "wallet": {
     "connect": "ربط المحفظة",
-    "disconnect": "فصل الاتصال",
+    "disconnect": "قطع الاتصال",
     "notInstalled": "محفظة Freighter غير مثبتة",
-    "balance": "الرصيد"
+    "balance": "الرصيد",
+    "address": "العنوان",
+    "network": "الشبكة"
   },
   "tip": {
     "title": "إرسال إكرامية",
     "amount": "المبلغ (XLM)",
-    "message": "الرسالة (اختياري)",
+    "message": "رسالة (اختياري)",
     "send": "إرسال الإكرامية",
-    "success": "تم إرسال الإكرامية بنجاح"
+    "success": "تم إرسال الإكرامية بنجاح",
+    "failed": "فشل إرسال الإكرامية",
+    "history": "سجل الإكراميات",
+    "received": "تم استلام إكرامية",
+    "newTip": "تم استلام إكرامية جديدة!"
+  },
+  "language": {
+    "select": "اختر اللغة",
+    "current": "اللغة الحالية"
+  },
+  "notifications": {
+    "title": "الإشعارات",
+    "markAllRead": "تحديد الكل كمقروء",
+    "noNotifications": "لا توجد إشعارات",
+    "connectionLive": "مباشر",
+    "connectionOffline": "غير متصل",
+    "connectionConnecting": "جارٍ الاتصال..."
+  },
+  "creator": {
+    "profile": "ملف المبدع",
+    "explore": "استكشاف المبدعين",
+    "support": "دعم هذا المبدع",
+    "tips": "الإكراميات المستلمة"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -4,25 +4,60 @@
     "loading": "Loading...",
     "error": "An error occurred",
     "submit": "Submit",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "save": "Save",
+    "delete": "Delete",
+    "edit": "Edit",
+    "close": "Close",
+    "search": "Search",
+    "back": "Back",
+    "next": "Next",
+    "confirm": "Confirm"
   },
   "nav": {
     "home": "Home",
     "explore": "Explore Creators",
     "tips": "Send a Tip",
-    "about": "About"
+    "about": "About",
+    "dashboard": "Dashboard",
+    "settings": "Settings",
+    "profile": "Profile"
   },
   "wallet": {
     "connect": "Connect Wallet",
     "disconnect": "Disconnect",
     "notInstalled": "Freighter wallet is not installed",
-    "balance": "Balance"
+    "balance": "Balance",
+    "address": "Address",
+    "network": "Network"
   },
   "tip": {
     "title": "Send a Tip",
     "amount": "Amount (XLM)",
     "message": "Message (Optional)",
     "send": "Send Tip",
-    "success": "Tip sent successfully"
+    "success": "Tip sent successfully",
+    "failed": "Failed to send tip",
+    "history": "Tip History",
+    "received": "Tip received",
+    "newTip": "New tip received!"
+  },
+  "language": {
+    "select": "Select language",
+    "current": "Current language"
+  },
+  "notifications": {
+    "title": "Notifications",
+    "markAllRead": "Mark all as read",
+    "noNotifications": "No notifications",
+    "connectionLive": "Live",
+    "connectionOffline": "Offline",
+    "connectionConnecting": "Connecting..."
+  },
+  "creator": {
+    "profile": "Creator Profile",
+    "explore": "Explore Creators",
+    "support": "Support this creator",
+    "tips": "Tips received"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -4,25 +4,60 @@
     "loading": "Cargando...",
     "error": "Ocurrió un error",
     "submit": "Enviar",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "delete": "Eliminar",
+    "edit": "Editar",
+    "close": "Cerrar",
+    "search": "Buscar",
+    "back": "Atrás",
+    "next": "Siguiente",
+    "confirm": "Confirmar"
   },
   "nav": {
     "home": "Inicio",
     "explore": "Explorar Creadores",
     "tips": "Enviar una Propina",
-    "about": "Acerca de"
+    "about": "Acerca de",
+    "dashboard": "Panel",
+    "settings": "Configuración",
+    "profile": "Perfil"
   },
   "wallet": {
     "connect": "Conectar Billetera",
     "disconnect": "Desconectar",
     "notInstalled": "La billetera Freighter no está instalada",
-    "balance": "Saldo"
+    "balance": "Saldo",
+    "address": "Dirección",
+    "network": "Red"
   },
   "tip": {
     "title": "Enviar una Propina",
     "amount": "Cantidad (XLM)",
     "message": "Mensaje (Opcional)",
     "send": "Enviar Propina",
-    "success": "Propina enviada exitosamente"
+    "success": "Propina enviada exitosamente",
+    "failed": "Error al enviar la propina",
+    "history": "Historial de Propinas",
+    "received": "Propina recibida",
+    "newTip": "¡Nueva propina recibida!"
+  },
+  "language": {
+    "select": "Seleccionar idioma",
+    "current": "Idioma actual"
+  },
+  "notifications": {
+    "title": "Notificaciones",
+    "markAllRead": "Marcar todo como leído",
+    "noNotifications": "Sin notificaciones",
+    "connectionLive": "En vivo",
+    "connectionOffline": "Sin conexión",
+    "connectionConnecting": "Conectando..."
+  },
+  "creator": {
+    "profile": "Perfil del Creador",
+    "explore": "Explorar Creadores",
+    "support": "Apoyar a este creador",
+    "tips": "Propinas recibidas"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -4,25 +4,60 @@
     "loading": "Chargement...",
     "error": "Une erreur s'est produite",
     "submit": "Soumettre",
-    "cancel": "Annuler"
+    "cancel": "Annuler",
+    "save": "Enregistrer",
+    "delete": "Supprimer",
+    "edit": "Modifier",
+    "close": "Fermer",
+    "search": "Rechercher",
+    "back": "Retour",
+    "next": "Suivant",
+    "confirm": "Confirmer"
   },
   "nav": {
     "home": "Accueil",
     "explore": "Explorer les Créateurs",
     "tips": "Envoyer un Pourboire",
-    "about": "À propos"
+    "about": "À propos",
+    "dashboard": "Tableau de bord",
+    "settings": "Paramètres",
+    "profile": "Profil"
   },
   "wallet": {
     "connect": "Connecter le Portefeuille",
     "disconnect": "Déconnecter",
     "notInstalled": "Le portefeuille Freighter n'est pas installé",
-    "balance": "Solde"
+    "balance": "Solde",
+    "address": "Adresse",
+    "network": "Réseau"
   },
   "tip": {
     "title": "Envoyer un Pourboire",
     "amount": "Montant (XLM)",
     "message": "Message (Optionnel)",
     "send": "Envoyer le Pourboire",
-    "success": "Pourboire envoyé avec succès"
+    "success": "Pourboire envoyé avec succès",
+    "failed": "Échec de l'envoi du pourboire",
+    "history": "Historique des Pourboires",
+    "received": "Pourboire reçu",
+    "newTip": "Nouveau pourboire reçu !"
+  },
+  "language": {
+    "select": "Sélectionner la langue",
+    "current": "Langue actuelle"
+  },
+  "notifications": {
+    "title": "Notifications",
+    "markAllRead": "Tout marquer comme lu",
+    "noNotifications": "Aucune notification",
+    "connectionLive": "En direct",
+    "connectionOffline": "Hors ligne",
+    "connectionConnecting": "Connexion..."
+  },
+  "creator": {
+    "profile": "Profil du Créateur",
+    "explore": "Explorer les Créateurs",
+    "support": "Soutenir ce créateur",
+    "tips": "Pourboires reçus"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -4,25 +4,60 @@
     "loading": "加载中...",
     "error": "发生错误",
     "submit": "提交",
-    "cancel": "取消"
+    "cancel": "取消",
+    "save": "保存",
+    "delete": "删除",
+    "edit": "编辑",
+    "close": "关闭",
+    "search": "搜索",
+    "back": "返回",
+    "next": "下一步",
+    "confirm": "确认"
   },
   "nav": {
     "home": "首页",
     "explore": "探索创作者",
     "tips": "发送小费",
-    "about": "关于"
+    "about": "关于",
+    "dashboard": "仪表板",
+    "settings": "设置",
+    "profile": "个人资料"
   },
   "wallet": {
     "connect": "连接钱包",
     "disconnect": "断开连接",
     "notInstalled": "Freighter 钱包未安装",
-    "balance": "余额"
+    "balance": "余额",
+    "address": "地址",
+    "network": "网络"
   },
   "tip": {
     "title": "发送小费",
     "amount": "金额 (XLM)",
     "message": "消息（可选）",
     "send": "发送小费",
-    "success": "小费发送成功"
+    "success": "小费发送成功",
+    "failed": "小费发送失败",
+    "history": "小费历史",
+    "received": "收到小费",
+    "newTip": "收到新小费！"
+  },
+  "language": {
+    "select": "选择语言",
+    "current": "当前语言"
+  },
+  "notifications": {
+    "title": "通知",
+    "markAllRead": "全部标为已读",
+    "noNotifications": "暂无通知",
+    "connectionLive": "实时",
+    "connectionOffline": "离线",
+    "connectionConnecting": "连接中..."
+  },
+  "creator": {
+    "profile": "创作者主页",
+    "explore": "探索创作者",
+    "support": "支持此创作者",
+    "tips": "收到的小费"
   }
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 import { getSecurityHeaders } from "./src/utils/security";
 
-const withNextIntl = createNextIntlPlugin();
+const withNextIntl = createNextIntlPlugin('./src/i18n.ts');
 
 // i18n is handled via next-intl with locale routing
 // Supported locales: en, es, fr, zh, ar, he — preference persisted in localStorage

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -19,11 +19,19 @@ export function LanguageSwitcher() {
   const [isPending, startTransition] = useTransition();
 
   const switchLanguage = (newLocale: string) => {
+    // Persist preference in localStorage
+    if (typeof window !== "undefined") {
+      localStorage.setItem("locale", newLocale);
+    }
+
     startTransition(() => {
-      // Remove current locale from pathname
+      // Strip existing locale prefix and prepend new one
       const segments = pathname.split("/");
-      segments.splice(1, 1); // Remove locale segment
-      const newPath = `/${newLocale}${segments.join("/")}`;
+      const knownLocales = languages.map((l) => l.code);
+      if (knownLocales.includes(segments[1])) {
+        segments.splice(1, 1);
+      }
+      const newPath = newLocale === "en" ? segments.join("/") || "/" : `/${newLocale}${segments.join("/")}`;
       router.replace(newPath);
     });
   };

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,16 @@
+import { getRequestConfig } from 'next-intl/server';
+import { routing } from './i18n/routing';
+
+export default getRequestConfig(async ({ requestLocale }) => {
+  let locale = await requestLocale;
+
+  // Validate locale against supported list, fall back to default
+  if (!locale || !routing.locales.includes(locale as any)) {
+    locale = routing.defaultLocale;
+  }
+
+  return {
+    locale,
+    messages: (await import(`../messages/${locale}.json`)).default,
+  };
+});


### PR DESCRIPTION
- Add src/i18n.ts as the central next-intl configuration entry point
- Update next.config.ts to use src/i18n.ts via createNextIntlPlugin
- Complete message files for English, Spanish, French, Chinese, Arabic
- All UI text translated: common, nav, wallet, tip, notifications, creator
- RTL support for Arabic via existing middleware and html dir attribute
- LanguageSwitcher persists preference to localStorage and handles locale URLs
- SEO-friendly locale URLs via next-intl routing (localePrefix: as-needed)
- Supported locales: en, es, fr, zh, ar

Closes #222