### PR TITLE
feat: implement gamification system

### DIFF
--- a/src/app/gamification/page.tsx
+++ b/src/app/gamification/page.tsx
@@ -1,12 +1,29 @@
 "use client";
 
-import { useGamification } from "@/hooks/useGamification";
-import { LevelProgress } from "@/components/LevelProgress";
-import { GamificationBadgeCard } from "@/components/GamificationBadge";
-import { AchievementCard } from "@/components/AchievementCard";
-import { RewardsList } from "@/components/RewardsList";
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { GamificationProvider, useGamificationContext } from "@/contexts/GamificationContext";
+import { LevelProgressCard } from "@/components/gamification/LevelProgressCard";
+import { BadgeGrid } from "@/components/gamification/BadgeGrid";
+import { AchievementList } from "@/components/gamification/AchievementList";
+import { RewardsShop } from "@/components/gamification/RewardsShop";
+import { GamificationLeaderboard } from "@/components/gamification/GamificationLeaderboard";
+import { GamificationStatsGrid } from "@/components/gamification/GamificationStats";
+import { XPHistory } from "@/components/gamification/XPHistory";
+import { XPToast } from "@/components/gamification/XPToast";
 
-export default function GamificationPage() {
+type Tab = "overview" | "badges" | "achievements" | "rewards" | "leaderboard" | "history";
+
+const TABS: { value: Tab; label: string; icon: string }[] = [
+  { value: "overview",     label: "Overview",     icon: "🏠" },
+  { value: "badges",       label: "Badges",       icon: "🏅" },
+  { value: "achievements", label: "Achievements", icon: "🏆" },
+  { value: "rewards",      label: "Rewards",      icon: "🎁" },
+  { value: "leaderboard",  label: "Leaderboard",  icon: "📊" },
+  { value: "history",      label: "XP History",   icon: "⚡" },
+];
+
+function GamificationContent() {
   const {
     isLoading,
     totalXP,
@@ -19,44 +36,52 @@ export default function GamificationPage() {
     achievements,
     rewards,
     stats,
-  } = useGamification();
+    xpHistory,
+    claimReward,
+  } = useGamificationContext();
+
+  const [activeTab, setActiveTab] = useState<Tab>("overview");
+  const [xpToast, setXpToast] = useState<{ amount: number; reason: string } | null>(null);
 
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-24">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-wave/20 border-t-wave" />
+        <div className="h-10 w-10 animate-spin rounded-full border-4 border-wave/20 border-t-wave" />
       </div>
     );
   }
 
-  const unlockedBadges = badges.filter((b) => b.unlocked).length;
-  const completedAchievements = achievements.filter((a) => a.completed).length;
-
   return (
-    <section className="space-y-8">
-      {/* Header */}
+    <section className="space-y-6">
+      {/* XP toast notification */}
+      {xpToast && (
+        <XPToast
+          amount={xpToast.amount}
+          reason={xpToast.reason}
+          onDone={() => setXpToast(null)}
+        />
+      )}
+
+      {/* Page header */}
       <div>
         <h1 className="text-3xl font-bold tracking-tight text-ink">Achievements & Rewards</h1>
-        <p className="mt-1 text-ink/60">Earn XP by tipping creators and unlock exclusive rewards.</p>
+        <p className="mt-1 text-ink/60">
+          Earn XP by tipping creators, unlock badges, and claim exclusive rewards.
+        </p>
       </div>
 
-      {/* Quick stats */}
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-        {[
-          { label: "Total XP",     value: totalXP.toLocaleString() },
-          { label: "Level",        value: `${currentLevel.level} — ${currentLevel.title}` },
-          { label: "Badges",       value: `${unlockedBadges} / ${badges.length}` },
-          { label: "Achievements", value: `${completedAchievements} / ${achievements.length}` },
-        ].map(({ label, value }) => (
-          <div key={label} className="rounded-2xl border border-ink/10 bg-[color:var(--surface)] p-4">
-            <p className="text-xs text-ink/50">{label}</p>
-            <p className="mt-1 font-bold text-ink">{value}</p>
-          </div>
-        ))}
-      </div>
+      {/* Stats grid */}
+      <GamificationStatsGrid
+        totalXP={totalXP}
+        currentLevelNum={currentLevel.level}
+        currentLevelTitle={currentLevel.title}
+        badges={badges}
+        achievements={achievements}
+        stats={stats}
+      />
 
       {/* Level progress */}
-      <LevelProgress
+      <LevelProgressCard
         totalXP={totalXP}
         currentLevel={currentLevel}
         nextLevel={nextLevel}
@@ -65,31 +90,95 @@ export default function GamificationPage() {
         xpNeeded={xpNeeded}
       />
 
-      {/* Badges */}
-      <div>
-        <h2 className="mb-4 text-xl font-semibold text-ink">Badges</h2>
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
-          {badges.map((badge) => (
-            <GamificationBadgeCard key={badge.id} badge={badge} />
-          ))}
-        </div>
+      {/* Tab navigation */}
+      <div className="flex gap-1 overflow-x-auto rounded-xl bg-ink/5 p-1 scrollbar-none">
+        {TABS.map((tab) => (
+          <button
+            key={tab.value}
+            onClick={() => setActiveTab(tab.value)}
+            className={`flex shrink-0 items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
+              activeTab === tab.value
+                ? "bg-[color:var(--surface)] text-ink shadow-sm"
+                : "text-ink/50 hover:text-ink"
+            }`}
+          >
+            <span aria-hidden="true">{tab.icon}</span>
+            {tab.label}
+          </button>
+        ))}
       </div>
 
-      {/* Achievements */}
-      <div>
-        <h2 className="mb-4 text-xl font-semibold text-ink">Achievements</h2>
-        <div className="grid gap-4 sm:grid-cols-2">
-          {achievements.map((achievement) => (
-            <AchievementCard key={achievement.id} achievement={achievement} />
-          ))}
-        </div>
-      </div>
+      {/* Tab content */}
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={activeTab}
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -10 }}
+          transition={{ duration: 0.2 }}
+        >
+          {activeTab === "overview" && (
+            <div className="space-y-8">
+              <div>
+                <h2 className="mb-4 text-xl font-semibold text-ink">Recent Badges</h2>
+                <BadgeGrid badges={badges.slice(0, 10)} />
+              </div>
+              <div>
+                <h2 className="mb-4 text-xl font-semibold text-ink">In-Progress Achievements</h2>
+                <AchievementList
+                  achievements={achievements.filter((a) => !a.completed && a.progress > 0).slice(0, 4)}
+                />
+              </div>
+            </div>
+          )}
 
-      {/* Rewards */}
-      <div>
-        <h2 className="mb-4 text-xl font-semibold text-ink">Rewards</h2>
-        <RewardsList rewards={rewards} totalXP={totalXP} />
-      </div>
+          {activeTab === "badges" && (
+            <div>
+              <h2 className="mb-4 text-xl font-semibold text-ink">Badge Collection</h2>
+              <BadgeGrid badges={badges} />
+            </div>
+          )}
+
+          {activeTab === "achievements" && (
+            <div>
+              <h2 className="mb-4 text-xl font-semibold text-ink">Achievements</h2>
+              <AchievementList achievements={achievements} />
+            </div>
+          )}
+
+          {activeTab === "rewards" && (
+            <div>
+              <h2 className="mb-4 text-xl font-semibold text-ink">Rewards Shop</h2>
+              <p className="mb-5 text-sm text-ink/50">
+                Spend your XP on exclusive cosmetics, features, and discounts.
+              </p>
+              <RewardsShop rewards={rewards} totalXP={totalXP} onClaim={claimReward} />
+            </div>
+          )}
+
+          {activeTab === "leaderboard" && (
+            <div>
+              <h2 className="mb-4 text-xl font-semibold text-ink">Leaderboard</h2>
+              <GamificationLeaderboard />
+            </div>
+          )}
+
+          {activeTab === "history" && (
+            <div>
+              <h2 className="mb-4 text-xl font-semibold text-ink">XP History</h2>
+              <XPHistory events={xpHistory} />
+            </div>
+          )}
+        </motion.div>
+      </AnimatePresence>
     </section>
+  );
+}
+
+export default function GamificationPage() {
+  return (
+    <GamificationProvider>
+      <GamificationContent />
+    </GamificationProvider>
   );
 }

--- a/src/components/AchievementCard.tsx
+++ b/src/components/AchievementCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ProgressBar } from "@/components/Progress/ProgressBar";
-import type { Achievement } from "@/hooks/useGamification";
+import type { Achievement } from "@/types/gamification";
 
 interface AchievementCardProps {
   achievement: Achievement;

--- a/src/components/GamificationBadge.tsx
+++ b/src/components/GamificationBadge.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { GamificationBadge } from "@/hooks/useGamification";
+import type { GamificationBadge } from "@/types/gamification";
 
 const rarityStyles: Record<GamificationBadge["rarity"], string> = {
   common:    "border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800/50",

--- a/src/components/LevelProgress.tsx
+++ b/src/components/LevelProgress.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ProgressBar } from "@/components/Progress/ProgressBar";
-import type { Level } from "@/hooks/useGamification";
+import type { Level } from "@/types/gamification";
 
 interface LevelProgressProps {
   totalXP: number;

--- a/src/components/RewardsList.tsx
+++ b/src/components/RewardsList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { Reward } from "@/hooks/useGamification";
+import type { Reward } from "@/types/gamification";
 
 interface RewardsListProps {
   rewards: Reward[];

--- a/src/components/gamification/AchievementList.tsx
+++ b/src/components/gamification/AchievementList.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { ProgressBar } from "@/components/Progress/ProgressBar";
+import type { Achievement, AchievementCategory } from "@/types/gamification";
+
+const categoryLabel: Record<AchievementCategory, string> = {
+  tipping:   "Tipping",
+  social:    "Social",
+  streak:    "Streak",
+  milestone: "Milestone",
+};
+
+const categoryColor: Record<AchievementCategory, string> = {
+  tipping:   "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+  social:    "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+  streak:    "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400",
+  milestone: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400",
+};
+
+type FilterOption = "all" | AchievementCategory | "completed" | "in-progress";
+
+interface AchievementListProps {
+  achievements: Achievement[];
+}
+
+export function AchievementList({ achievements }: AchievementListProps) {
+  const [filter, setFilter] = useState<FilterOption>("all");
+
+  const filters: { value: FilterOption; label: string }[] = [
+    { value: "all", label: "All" },
+    { value: "completed", label: "Completed" },
+    { value: "in-progress", label: "In Progress" },
+    { value: "tipping", label: "Tipping" },
+    { value: "social", label: "Social" },
+    { value: "streak", label: "Streak" },
+    { value: "milestone", label: "Milestone" },
+  ];
+
+  const filtered = achievements
+    .filter((a) => {
+      if (filter === "all") return true;
+      if (filter === "completed") return a.completed;
+      if (filter === "in-progress") return !a.completed && a.progress > 0;
+      return a.category === filter;
+    })
+    .sort((a, b) => {
+      // Completed last, then by progress percentage desc
+      if (a.completed !== b.completed) return a.completed ? 1 : -1;
+      const aPct = a.progress / a.target;
+      const bPct = b.progress / b.target;
+      return bPct - aPct;
+    });
+
+  const completedCount = achievements.filter((a) => a.completed).length;
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-ink/50">
+          {completedCount} / {achievements.length} completed
+        </p>
+        <div className="flex flex-wrap gap-1.5">
+          {filters.map((f) => (
+            <button
+              key={f.value}
+              onClick={() => setFilter(f.value)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                filter === f.value
+                  ? "bg-wave text-white"
+                  : "bg-ink/5 text-ink/60 hover:bg-ink/10"
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* List */}
+      <div className="grid gap-3 sm:grid-cols-2">
+        <AnimatePresence mode="popLayout">
+          {filtered.map((achievement) => {
+            const pct = Math.min((achievement.progress / achievement.target) * 100, 100);
+            return (
+              <motion.div
+                key={achievement.id}
+                layout
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -8 }}
+                className={`rounded-2xl border p-4 transition-colors ${
+                  achievement.completed
+                    ? "border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-900/20"
+                    : "border-ink/10 bg-[color:var(--surface)]"
+                }`}
+              >
+                <div className="flex items-start gap-3">
+                  <span className="text-3xl shrink-0" aria-hidden="true">{achievement.icon}</span>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-start justify-between gap-2 flex-wrap">
+                      <div>
+                        <p className="font-semibold text-ink text-sm">{achievement.name}</p>
+                        <span className={`inline-block mt-0.5 rounded-full px-2 py-0.5 text-[10px] font-semibold ${categoryColor[achievement.category]}`}>
+                          {categoryLabel[achievement.category]}
+                        </span>
+                      </div>
+                      <span className="shrink-0 text-xs font-bold text-wave">+{achievement.xpReward} XP</span>
+                    </div>
+                    <p className="text-xs text-ink/50 mt-1">{achievement.description}</p>
+                    <div className="mt-2">
+                      <ProgressBar
+                        progress={pct}
+                        max={100}
+                        color={achievement.completed ? "success" : "wave"}
+                        size="sm"
+                        showPercentage={false}
+                      />
+                      <p className="mt-1 text-xs text-ink/50 text-right">
+                        {achievement.completed
+                          ? "✓ Completed"
+                          : `${achievement.progress.toLocaleString()} / ${achievement.target.toLocaleString()}`}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </motion.div>
+            );
+          })}
+        </AnimatePresence>
+      </div>
+
+      {filtered.length === 0 && (
+        <div className="py-12 text-center text-ink/40">
+          <p className="text-4xl mb-2">🎯</p>
+          <p className="text-sm">No achievements match this filter</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/gamification/BadgeGrid.tsx
+++ b/src/components/gamification/BadgeGrid.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import type { GamificationBadge, BadgeRarity } from "@/types/gamification";
+
+const rarityBorder: Record<BadgeRarity, string> = {
+  common:    "border-gray-200 dark:border-gray-700",
+  rare:      "border-blue-300 dark:border-blue-700",
+  epic:      "border-purple-300 dark:border-purple-700",
+  legendary: "border-yellow-400 dark:border-yellow-600",
+};
+
+const rarityGlow: Record<BadgeRarity, string> = {
+  common:    "",
+  rare:      "shadow-blue-200 dark:shadow-blue-900",
+  epic:      "shadow-purple-200 dark:shadow-purple-900",
+  legendary: "shadow-yellow-200 dark:shadow-yellow-900",
+};
+
+const rarityLabel: Record<BadgeRarity, string> = {
+  common:    "text-gray-500",
+  rare:      "text-blue-500",
+  epic:      "text-purple-500",
+  legendary: "text-yellow-500",
+};
+
+const RARITY_ORDER: BadgeRarity[] = ["legendary", "epic", "rare", "common"];
+
+type FilterOption = "all" | BadgeRarity | "unlocked" | "locked";
+
+interface BadgeGridProps {
+  badges: GamificationBadge[];
+}
+
+export function BadgeGrid({ badges }: BadgeGridProps) {
+  const [filter, setFilter] = useState<FilterOption>("all");
+  const [selected, setSelected] = useState<GamificationBadge | null>(null);
+
+  const filters: { value: FilterOption; label: string }[] = [
+    { value: "all", label: "All" },
+    { value: "unlocked", label: "Unlocked" },
+    { value: "locked", label: "Locked" },
+    { value: "legendary", label: "Legendary" },
+    { value: "epic", label: "Epic" },
+    { value: "rare", label: "Rare" },
+    { value: "common", label: "Common" },
+  ];
+
+  const filtered = badges
+    .filter((b) => {
+      if (filter === "all") return true;
+      if (filter === "unlocked") return b.unlocked;
+      if (filter === "locked") return !b.unlocked;
+      return b.rarity === filter;
+    })
+    .sort((a, b) => {
+      // Unlocked first, then by rarity
+      if (a.unlocked !== b.unlocked) return a.unlocked ? -1 : 1;
+      return RARITY_ORDER.indexOf(a.rarity) - RARITY_ORDER.indexOf(b.rarity);
+    });
+
+  const unlockedCount = badges.filter((b) => b.unlocked).length;
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-ink/50">
+          {unlockedCount} / {badges.length} unlocked
+        </p>
+        <div className="flex flex-wrap gap-1.5">
+          {filters.map((f) => (
+            <button
+              key={f.value}
+              onClick={() => setFilter(f.value)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                filter === f.value
+                  ? "bg-wave text-white"
+                  : "bg-ink/5 text-ink/60 hover:bg-ink/10"
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Grid */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        <AnimatePresence mode="popLayout">
+          {filtered.map((badge) => (
+            <motion.button
+              key={badge.id}
+              layout
+              initial={{ opacity: 0, scale: 0.85 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.85 }}
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.97 }}
+              onClick={() => setSelected(badge)}
+              className={`relative flex flex-col items-center gap-2 rounded-2xl border p-4 text-center transition-shadow ${
+                rarityBorder[badge.rarity]
+              } ${badge.unlocked ? `shadow-md ${rarityGlow[badge.rarity]}` : "opacity-40 grayscale"} bg-[color:var(--surface)]`}
+              aria-label={`${badge.name} — ${badge.unlocked ? "unlocked" : "locked"}`}
+            >
+              {badge.unlocked && (
+                <span className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-green-500 text-[10px] text-white shadow">
+                  ✓
+                </span>
+              )}
+              <span className="text-4xl" aria-hidden="true">{badge.icon}</span>
+              <div>
+                <p className="text-xs font-semibold text-ink leading-tight">{badge.name}</p>
+                <p className={`text-[10px] font-medium capitalize mt-0.5 ${rarityLabel[badge.rarity]}`}>
+                  {badge.rarity}
+                </p>
+              </div>
+            </motion.button>
+          ))}
+        </AnimatePresence>
+      </div>
+
+      {/* Detail modal */}
+      <AnimatePresence>
+        {selected && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+            onClick={() => setSelected(null)}
+          >
+            <motion.div
+              initial={{ scale: 0.85, y: 20 }}
+              animate={{ scale: 1, y: 0 }}
+              exit={{ scale: 0.85, y: 20 }}
+              onClick={(e) => e.stopPropagation()}
+              className={`w-full max-w-sm rounded-3xl border-2 bg-[color:var(--surface)] p-8 text-center shadow-2xl ${rarityBorder[selected.rarity]}`}
+            >
+              <span className="text-7xl" aria-hidden="true">{selected.icon}</span>
+              <h3 className="mt-4 text-xl font-bold text-ink">{selected.name}</h3>
+              <p className={`text-sm font-semibold capitalize mt-1 ${rarityLabel[selected.rarity]}`}>
+                {selected.rarity}
+              </p>
+              <p className="mt-3 text-sm text-ink/60">{selected.description}</p>
+              <div className="mt-4 flex items-center justify-center gap-2 rounded-xl bg-wave/10 px-4 py-2">
+                <span className="text-wave font-bold">+{selected.xpReward} XP</span>
+                <span className="text-ink/40 text-xs">on unlock</span>
+              </div>
+              {selected.unlocked ? (
+                <p className="mt-3 text-xs text-green-600 font-semibold">✓ Unlocked</p>
+              ) : (
+                <p className="mt-3 text-xs text-ink/40 italic">Keep tipping to unlock this badge</p>
+              )}
+              <button
+                onClick={() => setSelected(null)}
+                className="mt-5 rounded-full bg-ink/5 px-6 py-2 text-sm font-medium text-ink/60 hover:bg-ink/10 transition-colors"
+              >
+                Close
+              </button>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/gamification/GamificationLeaderboard.tsx
+++ b/src/components/gamification/GamificationLeaderboard.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { useQuery } from "@tanstack/react-query";
+import { Crown, TrendingUp, TrendingDown, Minus } from "lucide-react";
+import { getGamificationLeaderboard } from "@/services/gamificationService";
+import { LevelBadge } from "./LevelBadge";
+import { LEVELS } from "@/services/gamificationService";
+import type { LeaderboardPeriod, LeaderboardEntry, BadgeRarity } from "@/types/gamification";
+import { generateAvatarUrl } from "@/utils/imageUtils";
+
+const PERIODS: { value: LeaderboardPeriod; label: string }[] = [
+  { value: "24h", label: "24h" },
+  { value: "7d", label: "7 Days" },
+  { value: "30d", label: "30 Days" },
+  { value: "all", label: "All Time" },
+];
+
+const TABS = [
+  { value: "tippers" as const, label: "Top Tippers", icon: "💸" },
+  { value: "creators" as const, label: "Top Creators", icon: "🎨" },
+];
+
+const rarityGlow: Record<BadgeRarity, string> = {
+  common:    "",
+  rare:      "ring-1 ring-blue-400",
+  epic:      "ring-1 ring-purple-400",
+  legendary: "ring-2 ring-yellow-400",
+};
+
+function RankMedal({ rank }: { rank: number }) {
+  if (rank === 1) return <Crown className="h-6 w-6 text-yellow-500" />;
+  if (rank === 2) return (
+    <div className="h-6 w-6 rounded-full bg-gray-300 flex items-center justify-center text-xs font-bold text-gray-700">2</div>
+  );
+  if (rank === 3) return (
+    <div className="h-6 w-6 rounded-full bg-amber-400 flex items-center justify-center text-xs font-bold text-white">3</div>
+  );
+  return <span className="text-sm font-bold text-ink/50 w-6 text-center">{rank}</span>;
+}
+
+function ChangeIndicator({ change }: { change: number }) {
+  if (change > 0) return (
+    <span className="flex items-center gap-0.5 text-xs font-medium text-emerald-600">
+      <TrendingUp className="h-3 w-3" />
+      {change.toFixed(1)}%
+    </span>
+  );
+  if (change < 0) return (
+    <span className="flex items-center gap-0.5 text-xs font-medium text-red-500">
+      <TrendingDown className="h-3 w-3" />
+      {Math.abs(change).toFixed(1)}%
+    </span>
+  );
+  return <Minus className="h-3 w-3 text-ink/30" />;
+}
+
+interface LeaderboardRowProps {
+  entry: LeaderboardEntry;
+  index: number;
+}
+
+function LeaderboardRow({ entry, index }: LeaderboardRowProps) {
+  const level = LEVELS.find((l) => l.level === entry.level) ?? LEVELS[0];
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, x: -16 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: 16 }}
+      transition={{ delay: index * 0.04, duration: 0.3 }}
+      className="flex items-center gap-3 rounded-2xl border border-ink/5 bg-[color:var(--surface)] px-4 py-3 hover:border-ink/10 hover:shadow-sm transition-all"
+    >
+      {/* Rank */}
+      <div className="w-8 flex items-center justify-center shrink-0">
+        <RankMedal rank={entry.rank} />
+      </div>
+
+      {/* Avatar */}
+      <div className="relative shrink-0">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={entry.avatarUrl ?? generateAvatarUrl(entry.name)}
+          alt={entry.name}
+          className="h-10 w-10 rounded-full object-cover ring-2 ring-white/20"
+        />
+        <div className="absolute -bottom-1 -right-1">
+          <LevelBadge level={level} size="sm" />
+        </div>
+      </div>
+
+      {/* Name + badges */}
+      <div className="flex-1 min-w-0">
+        <p className="font-semibold text-ink text-sm truncate">{entry.name}</p>
+        <div className="flex items-center gap-1 mt-0.5">
+          <span className={`text-xs font-medium ${level.color}`}>Lv.{entry.level}</span>
+          <span className="text-ink/20">·</span>
+          <span className="text-xs text-ink/40">{entry.xp.toLocaleString()} XP</span>
+          {entry.badges.slice(0, 3).map((b) => (
+            <span
+              key={b.id}
+              className={`text-sm rounded-full ${rarityGlow[b.rarity]}`}
+              title={b.id}
+              aria-hidden="true"
+            >
+              {b.icon}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Metric */}
+      <div className="text-right shrink-0">
+        <p className="font-bold text-wave text-sm">{entry.metric.toLocaleString()} XLM</p>
+        <ChangeIndicator change={entry.change24h} />
+      </div>
+    </motion.div>
+  );
+}
+
+export function GamificationLeaderboard() {
+  const [period, setPeriod] = useState<LeaderboardPeriod>("30d");
+  const [tab, setTab] = useState<"tippers" | "creators">("tippers");
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["gamification-leaderboard", period],
+    queryFn: () => getGamificationLeaderboard(period),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const entries: LeaderboardEntry[] = data?.[tab] ?? [];
+
+  return (
+    <div className="space-y-5">
+      {/* Controls */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        {/* Tabs */}
+        <div className="flex gap-1 rounded-xl bg-ink/5 p-1">
+          {TABS.map((t) => (
+            <button
+              key={t.value}
+              onClick={() => setTab(t.value)}
+              className={`flex items-center gap-1.5 rounded-lg px-4 py-1.5 text-sm font-medium transition-colors ${
+                tab === t.value
+                  ? "bg-[color:var(--surface)] text-ink shadow-sm"
+                  : "text-ink/50 hover:text-ink"
+              }`}
+            >
+              <span aria-hidden="true">{t.icon}</span>
+              {t.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Period */}
+        <div className="flex gap-1">
+          {PERIODS.map((p) => (
+            <button
+              key={p.value}
+              onClick={() => setPeriod(p.value)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                period === p.value
+                  ? "bg-wave text-white"
+                  : "bg-ink/5 text-ink/60 hover:bg-ink/10"
+              }`}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* List */}
+      {isLoading ? (
+        <div className="flex items-center justify-center py-16">
+          <div className="h-8 w-8 rounded-full border-4 border-wave/20 border-t-wave animate-spin" />
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <AnimatePresence mode="popLayout">
+            {entries.map((entry, i) => (
+              <LeaderboardRow key={`${entry.userId}-${i}`} entry={entry} index={i} />
+            ))}
+          </AnimatePresence>
+          {entries.length === 0 && (
+            <div className="py-12 text-center text-ink/40">
+              <p className="text-4xl mb-2">🏆</p>
+              <p className="text-sm">No data for this period yet</p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {data?.updatedAt && (
+        <p className="text-xs text-ink/30 text-right">
+          Updated {new Date(data.updatedAt).toLocaleTimeString()}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/gamification/GamificationStats.tsx
+++ b/src/components/gamification/GamificationStats.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { GamificationStats as Stats, GamificationBadge, Achievement } from "@/types/gamification";
+
+interface GamificationStatsProps {
+  totalXP: number;
+  currentLevelNum: number;
+  currentLevelTitle: string;
+  badges: GamificationBadge[];
+  achievements: Achievement[];
+  stats: Stats;
+}
+
+export function GamificationStatsGrid({
+  totalXP,
+  currentLevelNum,
+  currentLevelTitle,
+  badges,
+  achievements,
+  stats,
+}: GamificationStatsProps) {
+  const unlockedBadges = badges.filter((b) => b.unlocked).length;
+  const completedAchievements = achievements.filter((a) => a.completed).length;
+
+  const items = [
+    { label: "Total XP",     value: totalXP.toLocaleString(),                    icon: "⚡", color: "text-wave" },
+    { label: "Level",        value: `${currentLevelNum} — ${currentLevelTitle}`, icon: "🎖️", color: "text-purple-500" },
+    { label: "Badges",       value: `${unlockedBadges} / ${badges.length}`,      icon: "🏅", color: "text-yellow-500" },
+    { label: "Achievements", value: `${completedAchievements} / ${achievements.length}`, icon: "🏆", color: "text-green-500" },
+    { label: "Tips Sent",    value: stats.tipCount.toLocaleString(),              icon: "💸", color: "text-blue-500" },
+    { label: "XLM Tipped",  value: `${stats.totalTipped.toLocaleString()} XLM`,  icon: "🌟", color: "text-orange-500" },
+    { label: "Creators Supported", value: stats.uniqueRecipients.toLocaleString(), icon: "🤝", color: "text-pink-500" },
+    { label: "Streak",       value: `${stats.currentStreak} days`,               icon: "🔥", color: "text-red-500" },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      {items.map(({ label, value, icon, color }, i) => (
+        <motion.div
+          key={label}
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: i * 0.05 }}
+          className="rounded-2xl border border-ink/10 bg-[color:var(--surface)] p-4"
+        >
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-lg" aria-hidden="true">{icon}</span>
+            <p className="text-xs text-ink/50">{label}</p>
+          </div>
+          <p className={`font-bold text-sm ${color}`}>{value}</p>
+        </motion.div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/gamification/LevelBadge.tsx
+++ b/src/components/gamification/LevelBadge.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { Level } from "@/types/gamification";
+
+interface LevelBadgeProps {
+  level: Level;
+  size?: "sm" | "md" | "lg";
+  animated?: boolean;
+}
+
+const sizeMap = {
+  sm: { outer: "h-8 w-8 text-xs", icon: "text-sm" },
+  md: { outer: "h-12 w-12 text-sm", icon: "text-xl" },
+  lg: { outer: "h-16 w-16 text-base", icon: "text-3xl" },
+};
+
+export function LevelBadge({ level, size = "md", animated = false }: LevelBadgeProps) {
+  const s = sizeMap[size];
+
+  const badge = (
+    <div
+      className={`relative flex flex-col items-center justify-center rounded-full border-2 border-current font-bold ${s.outer} ${level.color} ${level.bgColor}`}
+      aria-label={`Level ${level.level}: ${level.title}`}
+    >
+      <span className={s.icon} aria-hidden="true">{level.icon}</span>
+    </div>
+  );
+
+  if (!animated) return badge;
+
+  return (
+    <motion.div
+      whileHover={{ scale: 1.1, rotate: [0, -5, 5, 0] }}
+      transition={{ duration: 0.4 }}
+    >
+      {badge}
+    </motion.div>
+  );
+}

--- a/src/components/gamification/LevelProgressCard.tsx
+++ b/src/components/gamification/LevelProgressCard.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { ProgressBar } from "@/components/Progress/ProgressBar";
+import { LevelBadge } from "./LevelBadge";
+import type { Level } from "@/types/gamification";
+
+interface LevelProgressCardProps {
+  totalXP: number;
+  currentLevel: Level;
+  nextLevel: Level | null;
+  levelProgress: number;
+  xpIntoLevel: number;
+  xpNeeded: number;
+}
+
+export function LevelProgressCard({
+  totalXP,
+  currentLevel,
+  nextLevel,
+  levelProgress,
+  xpIntoLevel,
+  xpNeeded,
+}: LevelProgressCardProps) {
+  const isMax = currentLevel.level === 5;
+
+  return (
+    <div className="rounded-2xl border border-ink/10 bg-[color:var(--surface)] p-6">
+      <div className="flex items-center gap-4 mb-5">
+        <LevelBadge level={currentLevel} size="lg" animated />
+        <div className="flex-1 min-w-0">
+          <p className="text-xs font-semibold uppercase tracking-wide text-ink/40">Current Level</p>
+          <p className={`text-2xl font-bold ${currentLevel.color}`}>
+            Lv.{currentLevel.level} — {currentLevel.title}
+          </p>
+          <p className="text-sm text-ink/50 mt-0.5">
+            {totalXP.toLocaleString()} XP total
+          </p>
+        </div>
+        {nextLevel && (
+          <div className="hidden sm:flex flex-col items-center gap-1 opacity-50">
+            <LevelBadge level={nextLevel} size="sm" />
+            <p className="text-xs text-ink/40">Next</p>
+          </div>
+        )}
+      </div>
+
+      <ProgressBar
+        progress={levelProgress}
+        max={100}
+        color="wave"
+        size="lg"
+        showPercentage={!isMax}
+        label={
+          isMax
+            ? "Max Level Reached 🎉"
+            : `${xpIntoLevel.toLocaleString()} / ${xpNeeded.toLocaleString()} XP to Lv.${nextLevel?.level}`
+        }
+      />
+
+      {!isMax && nextLevel && (
+        <div className="mt-3 flex items-center justify-between text-xs text-ink/40">
+          <span>{currentLevel.title}</span>
+          <motion.span
+            className={`font-semibold ${nextLevel.color}`}
+            animate={{ opacity: [0.6, 1, 0.6] }}
+            transition={{ duration: 2, repeat: Infinity }}
+          >
+            {nextLevel.title} →
+          </motion.span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/gamification/RewardsShop.tsx
+++ b/src/components/gamification/RewardsShop.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import type { Reward, RewardType } from "@/types/gamification";
+
+const typeLabel: Record<RewardType, string> = {
+  cosmetic:  "Cosmetic",
+  feature:   "Feature",
+  discount:  "Discount",
+  exclusive: "Exclusive",
+};
+
+const typeColor: Record<RewardType, string> = {
+  cosmetic:  "bg-pink-100 text-pink-700 dark:bg-pink-900/30 dark:text-pink-400",
+  feature:   "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+  discount:  "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+  exclusive: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
+};
+
+interface RewardsShopProps {
+  rewards: Reward[];
+  totalXP: number;
+  onClaim: (rewardId: string) => Promise<void>;
+}
+
+export function RewardsShop({ rewards, totalXP, onClaim }: RewardsShopProps) {
+  const [claiming, setClaiming] = useState<string | null>(null);
+  const [justClaimed, setJustClaimed] = useState<string | null>(null);
+
+  const handleClaim = async (reward: Reward) => {
+    if (!reward.available || reward.claimed || claiming) return;
+    setClaiming(reward.id);
+    try {
+      await onClaim(reward.id);
+      setJustClaimed(reward.id);
+      setTimeout(() => setJustClaimed(null), 2000);
+    } finally {
+      setClaiming(null);
+    }
+  };
+
+  const available = rewards.filter((r) => r.available && !r.claimed);
+  const locked = rewards.filter((r) => !r.available && !r.claimed);
+  const claimed = rewards.filter((r) => r.claimed);
+
+  return (
+    <div className="space-y-6">
+      {/* Available */}
+      {available.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-ink/60 uppercase tracking-wide mb-3">
+            Available to Claim
+          </h3>
+          <div className="space-y-3">
+            {available.map((reward) => (
+              <RewardRow
+                key={reward.id}
+                reward={reward}
+                totalXP={totalXP}
+                isClaiming={claiming === reward.id}
+                justClaimed={justClaimed === reward.id}
+                onClaim={() => handleClaim(reward)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Locked */}
+      {locked.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-ink/60 uppercase tracking-wide mb-3">
+            Locked
+          </h3>
+          <div className="space-y-3">
+            {locked.map((reward) => (
+              <RewardRow
+                key={reward.id}
+                reward={reward}
+                totalXP={totalXP}
+                isClaiming={false}
+                justClaimed={false}
+                onClaim={() => {}}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Claimed */}
+      {claimed.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-ink/60 uppercase tracking-wide mb-3">
+            Claimed
+          </h3>
+          <div className="space-y-3">
+            {claimed.map((reward) => (
+              <RewardRow
+                key={reward.id}
+                reward={reward}
+                totalXP={totalXP}
+                isClaiming={false}
+                justClaimed={false}
+                onClaim={() => {}}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface RewardRowProps {
+  reward: Reward;
+  totalXP: number;
+  isClaiming: boolean;
+  justClaimed: boolean;
+  onClaim: () => void;
+}
+
+function RewardRow({ reward, totalXP, isClaiming, justClaimed, onClaim }: RewardRowProps) {
+  const xpShort = reward.available ? 0 : reward.xpCost - totalXP;
+
+  return (
+    <motion.div
+      layout
+      className={`flex items-center gap-4 rounded-2xl border p-4 transition-colors ${
+        reward.claimed
+          ? "border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-900/20"
+          : reward.available
+          ? "border-wave/30 bg-wave/5"
+          : "border-ink/10 bg-[color:var(--surface)] opacity-60"
+      }`}
+    >
+      <span className="text-3xl shrink-0" aria-hidden="true">{reward.icon}</span>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <p className="font-semibold text-ink text-sm">{reward.name}</p>
+          <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${typeColor[reward.type]}`}>
+            {typeLabel[reward.type]}
+          </span>
+        </div>
+        <p className="text-xs text-ink/50 mt-0.5">{reward.description}</p>
+        {!reward.available && (
+          <p className="text-xs text-ink/40 mt-1">
+            Need {xpShort.toLocaleString()} more XP
+          </p>
+        )}
+      </div>
+
+      <div className="shrink-0">
+        <AnimatePresence mode="wait">
+          {reward.claimed ? (
+            <motion.span
+              key="claimed"
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              className="rounded-full bg-green-500 px-3 py-1 text-xs font-semibold text-white"
+            >
+              Claimed ✓
+            </motion.span>
+          ) : reward.available ? (
+            <motion.button
+              key="claim"
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.95 }}
+              onClick={onClaim}
+              disabled={isClaiming}
+              className="rounded-full bg-wave px-4 py-1.5 text-xs font-semibold text-white hover:bg-wave/90 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {isClaiming ? (
+                <span className="flex items-center gap-1.5">
+                  <span className="h-3 w-3 rounded-full border-2 border-white/30 border-t-white animate-spin" />
+                  Claiming…
+                </span>
+              ) : justClaimed ? (
+                "Claimed! 🎉"
+              ) : (
+                `Claim · ${reward.xpCost.toLocaleString()} XP`
+              )}
+            </motion.button>
+          ) : (
+            <span className="rounded-full border border-ink/10 px-3 py-1 text-xs text-ink/40">
+              {reward.xpCost.toLocaleString()} XP
+            </span>
+          )}
+        </AnimatePresence>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/gamification/XPHistory.tsx
+++ b/src/components/gamification/XPHistory.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { XPEvent } from "@/types/gamification";
+
+interface XPHistoryProps {
+  events: XPEvent[];
+}
+
+export function XPHistory({ events }: XPHistoryProps) {
+  if (events.length === 0) {
+    return (
+      <div className="py-10 text-center text-ink/40">
+        <p className="text-3xl mb-2">⚡</p>
+        <p className="text-sm">No XP events yet — start tipping!</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {events.map((event, i) => (
+        <motion.div
+          key={`${event.timestamp}-${i}`}
+          initial={{ opacity: 0, x: -12 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ delay: i * 0.04 }}
+          className="flex items-center justify-between rounded-xl border border-ink/5 bg-[color:var(--surface)] px-4 py-3"
+        >
+          <div className="flex items-center gap-3">
+            <span className="text-xl" aria-hidden="true">⚡</span>
+            <div>
+              <p className="text-sm font-medium text-ink">{event.reason}</p>
+              <p className="text-xs text-ink/40">
+                {new Date(event.timestamp).toLocaleDateString(undefined, {
+                  month: "short",
+                  day: "numeric",
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
+              </p>
+            </div>
+          </div>
+          <span className="text-sm font-bold text-wave">+{event.amount} XP</span>
+        </motion.div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/gamification/XPToast.tsx
+++ b/src/components/gamification/XPToast.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+
+interface XPToastProps {
+  amount: number;
+  reason: string;
+  onDone?: () => void;
+}
+
+export function XPToast({ amount, reason, onDone }: XPToastProps) {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setVisible(false);
+      setTimeout(() => onDone?.(), 400);
+    }, 2800);
+    return () => clearTimeout(t);
+  }, [onDone]);
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          initial={{ opacity: 0, y: 40, scale: 0.85 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: -20, scale: 0.9 }}
+          transition={{ type: "spring", stiffness: 400, damping: 28 }}
+          className="fixed bottom-24 right-6 z-50 flex items-center gap-3 rounded-2xl border border-wave/30 bg-[color:var(--surface)] px-5 py-3 shadow-2xl"
+          role="status"
+          aria-live="polite"
+        >
+          <span className="text-2xl" aria-hidden="true">⚡</span>
+          <div>
+            <p className="text-sm font-bold text-wave">+{amount} XP</p>
+            <p className="text-xs text-ink/60">{reason}</p>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/contexts/GamificationContext.tsx
+++ b/src/contexts/GamificationContext.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import React, { createContext, useContext, useState, useCallback, useEffect, ReactNode } from "react";
+import type { GamificationState, XPEvent } from "@/types/gamification";
+import {
+  getUserGamificationState,
+  claimReward as apiClaimReward,
+  getXPHistory,
+} from "@/services/gamificationService";
+
+interface GamificationContextValue extends GamificationState {
+  isLoading: boolean;
+  xpHistory: XPEvent[];
+  refresh: () => Promise<void>;
+  claimReward: (rewardId: string) => Promise<void>;
+  addXP: (amount: number, reason: string) => void;
+}
+
+const GamificationContext = createContext<GamificationContextValue | null>(null);
+
+export function useGamificationContext() {
+  const ctx = useContext(GamificationContext);
+  if (!ctx) throw new Error("useGamificationContext must be used within GamificationProvider");
+  return ctx;
+}
+
+interface GamificationProviderProps {
+  children: ReactNode;
+  username?: string;
+}
+
+export function GamificationProvider({ children, username = "demo-user" }: GamificationProviderProps) {
+  const [state, setState] = useState<GamificationState | null>(null);
+  const [xpHistory, setXpHistory] = useState<XPEvent[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const [gamificationData, history] = await Promise.all([
+        getUserGamificationState(username),
+        getXPHistory(username),
+      ]);
+      setState(gamificationData);
+      setXpHistory(history);
+    } catch (error) {
+      console.error("Failed to fetch gamification data:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [username]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const claimReward = useCallback(
+    async (rewardId: string) => {
+      if (!state) return;
+      try {
+        await apiClaimReward(username, rewardId);
+        // Optimistically update
+        setState((prev) =>
+          prev
+            ? {
+                ...prev,
+                rewards: prev.rewards.map((r) =>
+                  r.id === rewardId ? { ...r, claimed: true } : r
+                ),
+              }
+            : prev
+        );
+      } catch (error) {
+        console.error("Failed to claim reward:", error);
+      }
+    },
+    [state, username]
+  );
+
+  const addXP = useCallback((amount: number, reason: string) => {
+    setState((prev) => {
+      if (!prev) return prev;
+      const newTotalXP = prev.totalXP + amount;
+      // Recalculate level if needed (simplified — real impl would call service)
+      return {
+        ...prev,
+        totalXP: newTotalXP,
+        recentXPGain: { amount, reason },
+      };
+    });
+    setXpHistory((prev) => [{ amount, reason, timestamp: new Date().toISOString() }, ...prev]);
+  }, []);
+
+  if (!state) {
+    return (
+      <GamificationContext.Provider
+        value={{
+          isLoading,
+          totalXP: 0,
+          currentLevel: { level: 1, title: "Newcomer", minXP: 0, maxXP: 100, color: "text-gray-500", bgColor: "bg-gray-100", icon: "🌱" },
+          nextLevel: null,
+          levelProgress: 0,
+          xpIntoLevel: 0,
+          xpNeeded: 100,
+          badges: [],
+          achievements: [],
+          rewards: [],
+          stats: { tipCount: 0, totalTipped: 0, uniqueRecipients: 0, currentStreak: 0 },
+          xpHistory: [],
+          refresh,
+          claimReward,
+          addXP,
+        }}
+      >
+        {children}
+      </GamificationContext.Provider>
+    );
+  }
+
+  return (
+    <GamificationContext.Provider
+      value={{
+        ...state,
+        isLoading,
+        xpHistory,
+        refresh,
+        claimReward,
+        addXP,
+      }}
+    >
+      {children}
+    </GamificationContext.Provider>
+  );
+}

--- a/src/hooks/useGamification.ts
+++ b/src/hooks/useGamification.ts
@@ -1,218 +1,47 @@
 "use client";
 
+/**
+ * useGamification — lightweight hook for components that need gamification
+ * data without the full context provider (e.g. profile cards, tip wizard).
+ *
+ * For the full gamification page, use GamificationContext instead.
+ */
+
 import { useMemo } from "react";
-import { useTips } from "@/hooks/queries/useTips";
+import { useTips, type Tip } from "@/hooks/queries/useTips";
+import {
+  calculateXP,
+  getLevel,
+  getNextLevel,
+  buildBadges,
+  buildAchievements,
+  buildRewards,
+} from "@/services/gamificationService";
 
-// ── Types ──────────────────────────────────────────────────────────────────
-
-export interface GamificationBadge {
-  id: string;
-  name: string;
-  description: string;
-  icon: string;
-  unlocked: boolean;
-  unlockedAt?: string;
-  rarity: "common" | "rare" | "epic" | "legendary";
-}
-
-export interface Achievement {
-  id: string;
-  name: string;
-  description: string;
-  icon: string;
-  progress: number;   // current value
-  target: number;     // value needed to complete
-  completed: boolean;
-  xpReward: number;
-}
-
-export interface Level {
-  level: number;
-  title: string;
-  minXP: number;
-  maxXP: number;
-  color: string;
-}
-
-export interface Reward {
-  id: string;
-  name: string;
-  description: string;
-  icon: string;
-  xpCost: number;
-  claimed: boolean;
-  available: boolean;
-}
-
-// ── Level table ────────────────────────────────────────────────────────────
-
-const LEVELS: Level[] = [
-  { level: 1, title: "Newcomer",    minXP: 0,    maxXP: 100,  color: "text-gray-500" },
-  { level: 2, title: "Supporter",   minXP: 100,  maxXP: 300,  color: "text-green-500" },
-  { level: 3, title: "Contributor", minXP: 300,  maxXP: 600,  color: "text-blue-500" },
-  { level: 4, title: "Champion",    minXP: 600,  maxXP: 1000, color: "text-purple-500" },
-  { level: 5, title: "Legend",      minXP: 1000, maxXP: 1000, color: "text-yellow-500" },
-];
-
-function getLevel(xp: number): Level {
-  return [...LEVELS].reverse().find((l) => xp >= l.minXP) ?? LEVELS[0];
-}
-
-// ── Hook ──────────────────────────────────────────────────────────────────
+// Re-export types from the canonical types file for backward compatibility
+export type { GamificationBadge, Achievement, Level, Reward } from "@/types/gamification";
 
 export function useGamification() {
   const { data: tips = [], isLoading } = useTips();
 
   return useMemo(() => {
-    const completedTips = tips.filter((t) => t.status === "completed");
-    const totalTipped = completedTips.reduce((s, t) => s + t.amount, 0);
-    const uniqueRecipients = new Set(completedTips.map((t) => t.recipient)).size;
+    const completedTips = tips.filter((t: Tip) => t.status === "completed");
+    const totalTipped = completedTips.reduce((s: number, t: Tip) => s + t.amount, 0);
+    const uniqueRecipients = new Set(completedTips.map((t: Tip) => t.recipient)).size;
     const tipCount = completedTips.length;
+    const streak = 0; // streak comes from useTipStreak — default 0 here
 
-    // XP formula: 10 per tip + 1 per XLM tipped
-    const totalXP = tipCount * 10 + Math.floor(totalTipped);
+    const totalXP = calculateXP(tipCount, totalTipped, streak);
     const currentLevel = getLevel(totalXP);
-    const nextLevel = LEVELS.find((l) => l.level === currentLevel.level + 1) ?? currentLevel;
+    const nextLevel = getNextLevel(currentLevel);
     const xpIntoLevel = totalXP - currentLevel.minXP;
-    const xpNeeded = nextLevel.maxXP - currentLevel.minXP;
-    const levelProgress = currentLevel.level === 5 ? 100 : Math.min((xpIntoLevel / xpNeeded) * 100, 100);
+    const xpNeeded = (nextLevel?.minXP ?? currentLevel.minXP) - currentLevel.minXP || 1;
+    const levelProgress =
+      currentLevel.level === 5 ? 100 : Math.min((xpIntoLevel / xpNeeded) * 100, 100);
 
-    // ── Badges ──────────────────────────────────────────────────────────
-    const badges: GamificationBadge[] = [
-      {
-        id: "first-tip",
-        name: "First Tip",
-        description: "Send your first tip",
-        icon: "🎉",
-        rarity: "common",
-        unlocked: tipCount >= 1,
-      },
-      {
-        id: "generous",
-        name: "Generous",
-        description: "Tip 5 different creators",
-        icon: "💝",
-        rarity: "common",
-        unlocked: uniqueRecipients >= 5,
-      },
-      {
-        id: "big-spender",
-        name: "Big Spender",
-        description: "Send a tip of 100+ XLM",
-        icon: "💰",
-        rarity: "rare",
-        unlocked: completedTips.some((t) => t.amount >= 100),
-      },
-      {
-        id: "loyal",
-        name: "Loyal Fan",
-        description: "Send 10 tips total",
-        icon: "⭐",
-        rarity: "rare",
-        unlocked: tipCount >= 10,
-      },
-      {
-        id: "whale",
-        name: "Whale",
-        description: "Tip 500+ XLM total",
-        icon: "🐋",
-        rarity: "epic",
-        unlocked: totalTipped >= 500,
-      },
-      {
-        id: "legend",
-        name: "Legend",
-        description: "Reach Level 5",
-        icon: "👑",
-        rarity: "legendary",
-        unlocked: currentLevel.level >= 5,
-      },
-    ];
-
-    // ── Achievements ────────────────────────────────────────────────────
-    const achievements: Achievement[] = [
-      {
-        id: "tips-5",
-        name: "Getting Started",
-        description: "Send 5 tips",
-        icon: "🚀",
-        progress: Math.min(tipCount, 5),
-        target: 5,
-        completed: tipCount >= 5,
-        xpReward: 50,
-      },
-      {
-        id: "tips-25",
-        name: "Regular Tipper",
-        description: "Send 25 tips",
-        icon: "🔥",
-        progress: Math.min(tipCount, 25),
-        target: 25,
-        completed: tipCount >= 25,
-        xpReward: 200,
-      },
-      {
-        id: "amount-100",
-        name: "Century Club",
-        description: "Tip 100 XLM total",
-        icon: "💯",
-        progress: Math.min(totalTipped, 100),
-        target: 100,
-        completed: totalTipped >= 100,
-        xpReward: 100,
-      },
-      {
-        id: "creators-3",
-        name: "Community Builder",
-        description: "Support 3 different creators",
-        icon: "🤝",
-        progress: Math.min(uniqueRecipients, 3),
-        target: 3,
-        completed: uniqueRecipients >= 3,
-        xpReward: 75,
-      },
-      {
-        id: "amount-500",
-        name: "Mega Supporter",
-        description: "Tip 500 XLM total",
-        icon: "🏆",
-        progress: Math.min(totalTipped, 500),
-        target: 500,
-        completed: totalTipped >= 500,
-        xpReward: 500,
-      },
-    ];
-
-    // ── Rewards ─────────────────────────────────────────────────────────
-    const rewards: Reward[] = [
-      {
-        id: "profile-frame",
-        name: "Gold Profile Frame",
-        description: "Exclusive gold border on your profile",
-        icon: "🖼️",
-        xpCost: 200,
-        claimed: false,
-        available: totalXP >= 200,
-      },
-      {
-        id: "custom-badge",
-        name: "Custom Badge Slot",
-        description: "Unlock a custom badge display slot",
-        icon: "🎖️",
-        xpCost: 400,
-        claimed: false,
-        available: totalXP >= 400,
-      },
-      {
-        id: "early-access",
-        name: "Early Access",
-        description: "Get early access to new features",
-        icon: "⚡",
-        xpCost: 600,
-        claimed: false,
-        available: totalXP >= 600,
-      },
-    ];
+    const badges = buildBadges(tipCount, totalTipped, uniqueRecipients, currentLevel.level, streak);
+    const achievements = buildAchievements(tipCount, totalTipped, uniqueRecipients, streak);
+    const rewards = buildRewards(totalXP, []);
 
     return {
       isLoading,
@@ -225,7 +54,7 @@ export function useGamification() {
       badges,
       achievements,
       rewards,
-      stats: { tipCount, totalTipped, uniqueRecipients },
+      stats: { tipCount, totalTipped, uniqueRecipients, currentStreak: streak },
     };
   }, [tips, isLoading]);
 }

--- a/src/services/gamificationService.ts
+++ b/src/services/gamificationService.ts
@@ -1,0 +1,485 @@
+import type {
+  GamificationState,
+  LeaderboardData,
+  LeaderboardPeriod,
+  Level,
+  GamificationBadge,
+  Achievement,
+  Reward,
+  XPEvent,
+} from "@/types/gamification";
+import { generateAvatarUrl } from "@/utils/imageUtils";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+// ── Level table ────────────────────────────────────────────────────────────
+
+export const LEVELS: Level[] = [
+  { level: 1, title: "Newcomer",    minXP: 0,    maxXP: 100,  color: "text-gray-500",   bgColor: "bg-gray-100",   icon: "🌱" },
+  { level: 2, title: "Supporter",   minXP: 100,  maxXP: 300,  color: "text-green-600",  bgColor: "bg-green-100",  icon: "⭐" },
+  { level: 3, title: "Contributor", minXP: 300,  maxXP: 600,  color: "text-blue-600",   bgColor: "bg-blue-100",   icon: "🔥" },
+  { level: 4, title: "Champion",    minXP: 600,  maxXP: 1000, color: "text-purple-600", bgColor: "bg-purple-100", icon: "💎" },
+  { level: 5, title: "Legend",      minXP: 1000, maxXP: 1000, color: "text-yellow-500", bgColor: "bg-yellow-100", icon: "👑" },
+];
+
+export function getLevel(xp: number): Level {
+  return [...LEVELS].reverse().find((l) => xp >= l.minXP) ?? LEVELS[0];
+}
+
+export function getNextLevel(current: Level): Level | null {
+  return LEVELS.find((l) => l.level === current.level + 1) ?? null;
+}
+
+// ── XP calculation ─────────────────────────────────────────────────────────
+
+export function calculateXP(tipCount: number, totalTipped: number, streak: number): number {
+  const base = tipCount * 10 + Math.floor(totalTipped);
+  const streakBonus = streak > 0 ? Math.floor(streak * 2) : 0;
+  return base + streakBonus;
+}
+
+// ── Badge definitions ──────────────────────────────────────────────────────
+
+export function buildBadges(
+  tipCount: number,
+  totalTipped: number,
+  uniqueRecipients: number,
+  currentLevelNum: number,
+  streak: number,
+): GamificationBadge[] {
+  return [
+    {
+      id: "first-tip",
+      name: "First Tip",
+      description: "Send your first tip",
+      icon: "🎉",
+      rarity: "common",
+      xpReward: 20,
+      unlocked: tipCount >= 1,
+    },
+    {
+      id: "generous",
+      name: "Generous",
+      description: "Tip 5 different creators",
+      icon: "💝",
+      rarity: "common",
+      xpReward: 30,
+      unlocked: uniqueRecipients >= 5,
+    },
+    {
+      id: "loyal",
+      name: "Loyal Fan",
+      description: "Send 10 tips total",
+      icon: "⭐",
+      rarity: "rare",
+      xpReward: 75,
+      unlocked: tipCount >= 10,
+    },
+    {
+      id: "big-spender",
+      name: "Big Spender",
+      description: "Send a single tip of 100+ XLM",
+      icon: "💰",
+      rarity: "rare",
+      xpReward: 100,
+      unlocked: false, // requires per-tip data — set externally
+    },
+    {
+      id: "streak-7",
+      name: "Week Warrior",
+      description: "Maintain a 7-day tipping streak",
+      icon: "🔥",
+      rarity: "rare",
+      xpReward: 150,
+      unlocked: streak >= 7,
+    },
+    {
+      id: "community",
+      name: "Community Pillar",
+      description: "Support 10 different creators",
+      icon: "🤝",
+      rarity: "epic",
+      xpReward: 200,
+      unlocked: uniqueRecipients >= 10,
+    },
+    {
+      id: "whale",
+      name: "Whale",
+      description: "Tip 500+ XLM total",
+      icon: "🐋",
+      rarity: "epic",
+      xpReward: 300,
+      unlocked: totalTipped >= 500,
+    },
+    {
+      id: "streak-30",
+      name: "Monthly Master",
+      description: "Maintain a 30-day tipping streak",
+      icon: "🌙",
+      rarity: "epic",
+      xpReward: 400,
+      unlocked: streak >= 30,
+    },
+    {
+      id: "legend",
+      name: "Legend",
+      description: "Reach Level 5",
+      icon: "👑",
+      rarity: "legendary",
+      xpReward: 500,
+      unlocked: currentLevelNum >= 5,
+    },
+    {
+      id: "mega-whale",
+      name: "Mega Whale",
+      description: "Tip 2000+ XLM total",
+      icon: "🌊",
+      rarity: "legendary",
+      xpReward: 1000,
+      unlocked: totalTipped >= 2000,
+    },
+  ];
+}
+
+// ── Achievement definitions ────────────────────────────────────────────────
+
+export function buildAchievements(
+  tipCount: number,
+  totalTipped: number,
+  uniqueRecipients: number,
+  streak: number,
+): Achievement[] {
+  return [
+    {
+      id: "tips-1",
+      name: "First Steps",
+      description: "Send your first tip",
+      icon: "🚀",
+      category: "tipping",
+      progress: Math.min(tipCount, 1),
+      target: 1,
+      completed: tipCount >= 1,
+      xpReward: 25,
+    },
+    {
+      id: "tips-5",
+      name: "Getting Started",
+      description: "Send 5 tips",
+      icon: "✨",
+      category: "tipping",
+      progress: Math.min(tipCount, 5),
+      target: 5,
+      completed: tipCount >= 5,
+      xpReward: 50,
+    },
+    {
+      id: "tips-25",
+      name: "Regular Tipper",
+      description: "Send 25 tips",
+      icon: "🔥",
+      category: "tipping",
+      progress: Math.min(tipCount, 25),
+      target: 25,
+      completed: tipCount >= 25,
+      xpReward: 200,
+    },
+    {
+      id: "tips-100",
+      name: "Tip Machine",
+      description: "Send 100 tips",
+      icon: "⚡",
+      category: "tipping",
+      progress: Math.min(tipCount, 100),
+      target: 100,
+      completed: tipCount >= 100,
+      xpReward: 500,
+    },
+    {
+      id: "amount-50",
+      name: "Half Century",
+      description: "Tip 50 XLM total",
+      icon: "💫",
+      category: "milestone",
+      progress: Math.min(totalTipped, 50),
+      target: 50,
+      completed: totalTipped >= 50,
+      xpReward: 50,
+    },
+    {
+      id: "amount-100",
+      name: "Century Club",
+      description: "Tip 100 XLM total",
+      icon: "💯",
+      category: "milestone",
+      progress: Math.min(totalTipped, 100),
+      target: 100,
+      completed: totalTipped >= 100,
+      xpReward: 100,
+    },
+    {
+      id: "amount-500",
+      name: "Mega Supporter",
+      description: "Tip 500 XLM total",
+      icon: "🏆",
+      category: "milestone",
+      progress: Math.min(totalTipped, 500),
+      target: 500,
+      completed: totalTipped >= 500,
+      xpReward: 500,
+    },
+    {
+      id: "creators-3",
+      name: "Community Builder",
+      description: "Support 3 different creators",
+      icon: "🤝",
+      category: "social",
+      progress: Math.min(uniqueRecipients, 3),
+      target: 3,
+      completed: uniqueRecipients >= 3,
+      xpReward: 75,
+    },
+    {
+      id: "creators-10",
+      name: "Super Connector",
+      description: "Support 10 different creators",
+      icon: "🌐",
+      category: "social",
+      progress: Math.min(uniqueRecipients, 10),
+      target: 10,
+      completed: uniqueRecipients >= 10,
+      xpReward: 200,
+    },
+    {
+      id: "streak-3",
+      name: "On a Roll",
+      description: "Tip 3 days in a row",
+      icon: "🎯",
+      category: "streak",
+      progress: Math.min(streak, 3),
+      target: 3,
+      completed: streak >= 3,
+      xpReward: 60,
+    },
+    {
+      id: "streak-7",
+      name: "Week Warrior",
+      description: "Tip 7 days in a row",
+      icon: "🔥",
+      category: "streak",
+      progress: Math.min(streak, 7),
+      target: 7,
+      completed: streak >= 7,
+      xpReward: 150,
+    },
+    {
+      id: "streak-30",
+      name: "Monthly Master",
+      description: "Tip 30 days in a row",
+      icon: "🌙",
+      category: "streak",
+      progress: Math.min(streak, 30),
+      target: 30,
+      completed: streak >= 30,
+      xpReward: 500,
+    },
+  ];
+}
+
+// ── Reward definitions ─────────────────────────────────────────────────────
+
+export function buildRewards(totalXP: number, claimedIds: string[]): Reward[] {
+  const defs: Omit<Reward, "claimed" | "available">[] = [
+    {
+      id: "profile-frame-silver",
+      name: "Silver Profile Frame",
+      description: "Exclusive silver border on your profile",
+      icon: "🖼️",
+      type: "cosmetic",
+      xpCost: 100,
+    },
+    {
+      id: "profile-frame-gold",
+      name: "Gold Profile Frame",
+      description: "Exclusive gold border on your profile",
+      icon: "🏅",
+      type: "cosmetic",
+      xpCost: 250,
+    },
+    {
+      id: "custom-badge",
+      name: "Custom Badge Slot",
+      description: "Unlock a custom badge display slot on your profile",
+      icon: "🎖️",
+      type: "cosmetic",
+      xpCost: 400,
+    },
+    {
+      id: "early-access",
+      name: "Early Access",
+      description: "Get early access to new features before public release",
+      icon: "⚡",
+      type: "feature",
+      xpCost: 600,
+    },
+    {
+      id: "fee-discount",
+      name: "5% Fee Discount",
+      description: "Reduce platform fees by 5% for 30 days",
+      icon: "💸",
+      type: "discount",
+      xpCost: 800,
+    },
+    {
+      id: "vip-badge",
+      name: "VIP Badge",
+      description: "Exclusive VIP badge visible on all your tips",
+      icon: "💎",
+      type: "exclusive",
+      xpCost: 1000,
+    },
+  ];
+
+  return defs.map((d) => ({
+    ...d,
+    claimed: claimedIds.includes(d.id),
+    available: totalXP >= d.xpCost,
+  }));
+}
+
+// ── API calls (with mock fallback) ─────────────────────────────────────────
+
+async function apiFetch<T>(path: string): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    headers: { "Content-Type": "application/json" },
+    next: { revalidate: 60 },
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json() as Promise<T>;
+}
+
+export async function getUserGamificationState(username: string): Promise<GamificationState> {
+  try {
+    return await apiFetch<GamificationState>(`/users/${username}/gamification`);
+  } catch {
+    // Mock fallback
+    const tipCount = 12;
+    const totalTipped = 340;
+    const uniqueRecipients = 7;
+    const streak = 5;
+    const totalXP = calculateXP(tipCount, totalTipped, streak);
+    const currentLevel = getLevel(totalXP);
+    const nextLevel = getNextLevel(currentLevel);
+    const xpIntoLevel = totalXP - currentLevel.minXP;
+    const xpNeeded = (nextLevel?.minXP ?? currentLevel.minXP) - currentLevel.minXP;
+    const levelProgress = currentLevel.level === 5 ? 100 : Math.min((xpIntoLevel / xpNeeded) * 100, 100);
+
+    return {
+      totalXP,
+      currentLevel,
+      nextLevel,
+      levelProgress,
+      xpIntoLevel,
+      xpNeeded: xpNeeded || 1,
+      badges: buildBadges(tipCount, totalTipped, uniqueRecipients, currentLevel.level, streak),
+      achievements: buildAchievements(tipCount, totalTipped, uniqueRecipients, streak),
+      rewards: buildRewards(totalXP, []),
+      stats: { tipCount, totalTipped, uniqueRecipients, currentStreak: streak },
+    };
+  }
+}
+
+export async function claimReward(username: string, rewardId: string): Promise<void> {
+  try {
+    const res = await fetch(`${API_BASE}/users/${username}/rewards/${rewardId}/claim`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+    if (!res.ok) throw new Error("Failed to claim reward");
+  } catch {
+    // Silently handled — UI updates optimistically
+  }
+}
+
+export async function getXPHistory(username: string): Promise<XPEvent[]> {
+  try {
+    return await apiFetch<XPEvent[]>(`/users/${username}/xp-history`);
+  } catch {
+    const now = Date.now();
+    return [
+      { amount: 10, reason: "Sent a tip", timestamp: new Date(now - 86400000).toISOString() },
+      { amount: 50, reason: "Achievement: Getting Started", timestamp: new Date(now - 172800000).toISOString() },
+      { amount: 10, reason: "Sent a tip", timestamp: new Date(now - 259200000).toISOString() },
+      { amount: 75, reason: "Achievement: Community Builder", timestamp: new Date(now - 345600000).toISOString() },
+      { amount: 10, reason: "Sent a tip", timestamp: new Date(now - 432000000).toISOString() },
+    ];
+  }
+}
+
+export async function getGamificationLeaderboard(period: LeaderboardPeriod): Promise<LeaderboardData> {
+  try {
+    return await apiFetch<LeaderboardData>(`/leaderboards/gamification?period=${period}`);
+  } catch {
+    const scale: Record<LeaderboardPeriod, number> = { "24h": 0.1, "7d": 0.4, "30d": 1, all: 2 };
+    const s = scale[period];
+
+    const tippers = [
+      { name: "xlm-whale",       xp: 1800, metric: 12500, level: 5 },
+      { name: "stellar-max",     xp: 1200, metric: 9800,  level: 5 },
+      { name: "defi-donor",      xp: 980,  metric: 7500,  level: 4 },
+      { name: "crypto-angel",    xp: 760,  metric: 6200,  level: 4 },
+      { name: "nft-supporter",   xp: 620,  metric: 4800,  level: 3 },
+      { name: "blockchain-backer", xp: 540, metric: 4200, level: 3 },
+      { name: "web3-warrior",    xp: 480,  metric: 3800,  level: 3 },
+      { name: "tip-machine",     xp: 420,  metric: 3400,  level: 2 },
+      { name: "stellar-fan",     xp: 380,  metric: 3100,  level: 2 },
+      { name: "xlm-lover",       xp: 320,  metric: 2900,  level: 2 },
+    ].map((e, i) => ({
+      rank: i + 1,
+      userId: e.name,
+      name: e.name,
+      avatarUrl: generateAvatarUrl(e.name),
+      metric: Math.round(e.metric * s),
+      xp: Math.round(e.xp * s),
+      level: e.level,
+      change24h: parseFloat(((Math.random() - 0.4) * 20).toFixed(1)),
+      badges: buildBadges(
+        Math.round(e.metric * s / 100),
+        Math.round(e.metric * s),
+        Math.round(e.xp * s / 200),
+        e.level,
+        Math.round(e.xp * s / 100),
+      )
+        .filter((b) => b.unlocked)
+        .slice(0, 3)
+        .map(({ id, icon, rarity }) => ({ id, icon, rarity })),
+    }));
+
+    const creators = [
+      { name: "stellar-dev", xp: 2100, metric: 15000, level: 5 },
+      { name: "alice",       xp: 1600, metric: 11200, level: 5 },
+      { name: "nft-queen",   xp: 1200, metric: 8900,  level: 5 },
+      { name: "defi-guru",   xp: 980,  metric: 7600,  level: 4 },
+      { name: "art-star",    xp: 760,  metric: 6400,  level: 4 },
+    ].map((e, i) => ({
+      rank: i + 1,
+      userId: e.name,
+      name: e.name,
+      avatarUrl: generateAvatarUrl(e.name),
+      metric: Math.round(e.metric * s),
+      xp: Math.round(e.xp * s),
+      level: e.level,
+      change24h: parseFloat(((Math.random() - 0.4) * 20).toFixed(1)),
+      badges: buildBadges(0, Math.round(e.metric * s), 0, e.level, 0)
+        .filter((b) => b.unlocked)
+        .slice(0, 3)
+        .map(({ id, icon, rarity }) => ({ id, icon, rarity })),
+    }));
+
+    return {
+      tippers,
+      creators,
+      biggest: tippers.slice(0, 5),
+      updatedAt: new Date().toISOString(),
+    };
+  }
+}

--- a/src/types/gamification.ts
+++ b/src/types/gamification.ts
@@ -1,0 +1,116 @@
+// ── Core gamification types ────────────────────────────────────────────────
+
+export type BadgeRarity = "common" | "rare" | "epic" | "legendary";
+export type AchievementCategory = "tipping" | "social" | "streak" | "milestone";
+export type RewardType = "cosmetic" | "feature" | "discount" | "exclusive";
+export type LeaderboardPeriod = "24h" | "7d" | "30d" | "all";
+
+// ── Level ──────────────────────────────────────────────────────────────────
+
+export interface Level {
+  level: number;
+  title: string;
+  minXP: number;
+  maxXP: number;
+  color: string;
+  bgColor: string;
+  icon: string;
+}
+
+// ── Badge ──────────────────────────────────────────────────────────────────
+
+export interface GamificationBadge {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  rarity: BadgeRarity;
+  unlocked: boolean;
+  unlockedAt?: string;
+  /** XP awarded when first unlocked */
+  xpReward: number;
+}
+
+// ── Achievement ────────────────────────────────────────────────────────────
+
+export interface Achievement {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  category: AchievementCategory;
+  progress: number;
+  target: number;
+  completed: boolean;
+  completedAt?: string;
+  xpReward: number;
+}
+
+// ── Reward ─────────────────────────────────────────────────────────────────
+
+export interface Reward {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  type: RewardType;
+  xpCost: number;
+  claimed: boolean;
+  available: boolean;
+  /** ISO date when reward expires, if any */
+  expiresAt?: string;
+}
+
+// ── Leaderboard ────────────────────────────────────────────────────────────
+
+export interface LeaderboardEntry {
+  rank: number;
+  userId: string;
+  name: string;
+  avatarUrl?: string;
+  /** Primary metric value (XLM tipped / received) */
+  metric: number;
+  /** XP earned */
+  xp: number;
+  level: number;
+  change24h: number;
+  badges: Pick<GamificationBadge, "id" | "icon" | "rarity">[];
+}
+
+export interface LeaderboardData {
+  tippers: LeaderboardEntry[];
+  creators: LeaderboardEntry[];
+  biggest: LeaderboardEntry[];
+  updatedAt: string;
+}
+
+// ── User gamification state ────────────────────────────────────────────────
+
+export interface GamificationStats {
+  tipCount: number;
+  totalTipped: number;
+  uniqueRecipients: number;
+  currentStreak: number;
+}
+
+export interface GamificationState {
+  totalXP: number;
+  currentLevel: Level;
+  nextLevel: Level | null;
+  levelProgress: number;
+  xpIntoLevel: number;
+  xpNeeded: number;
+  badges: GamificationBadge[];
+  achievements: Achievement[];
+  rewards: Reward[];
+  stats: GamificationStats;
+  recentXPGain?: { amount: number; reason: string };
+}
+
+// ── XP event ──────────────────────────────────────────────────────────────
+
+export interface XPEvent {
+  amount: number;
+  reason: string;
+  timestamp: string;
+}


### PR DESCRIPTION
- Add canonical types in src/types/gamification.ts (Level, Badge, Achievement, Reward, Leaderboard)
- Add gamificationService with XP calculation, badge/achievement/reward builders, and API calls with mock fallback
- Add GamificationContext for app-wide state management with claimReward and addXP actions
- Refactor useGamification hook to use shared service and types
- New components: LevelBadge, LevelProgressCard, BadgeGrid (with rarity filter + detail modal), AchievementList (with category filter), RewardsShop (available/locked/claimed sections), GamificationLeaderboard (with XP/level/badges per entry), GamificationStatsGrid, XPHistory, XPToast
- Rewrite gamification page with tabbed layout: Overview, Badges, Achievements, Rewards, Leaderboard, XP History
- Update AchievementCard, GamificationBadge, LevelProgress, RewardsList to import from canonical types
closes #370 