### PR TITLE
feat: implement audio waveform visualization

### DIFF
--- a/src/app/audio/page.tsx
+++ b/src/app/audio/page.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import { AudioWaveformPlayer } from "@/components/audio/AudioWaveformPlayer";
+import type { WaveformRegion } from "@/types/audio";
+
+// Demo tracks — replace with real URLs or dynamic data
+const DEMO_TRACKS = [
+  {
+    id: "1",
+    title: "Demo Track — Ambient Loop",
+    url: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3",
+    duration: "3:42",
+  },
+  {
+    id: "2",
+    title: "Demo Track — Electronic Beat",
+    url: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3",
+    duration: "4:15",
+  },
+];
+
+export default function AudioPage() {
+  const [activeTrack, setActiveTrack] = useState(DEMO_TRACKS[0]);
+  const [regions, setRegions] = useState<WaveformRegion[]>([]);
+
+  return (
+    <section className="space-y-8">
+      {/* Header */}
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight text-ink">Audio Waveform</h1>
+        <p className="mt-1 text-ink/60">
+          Interactive waveform visualisation with zoom, region selection, and playback controls.
+        </p>
+      </div>
+
+      {/* Track selector */}
+      <div className="flex gap-2 flex-wrap">
+        {DEMO_TRACKS.map((track) => (
+          <button
+            key={track.id}
+            type="button"
+            onClick={() => setActiveTrack(track)}
+            className={`rounded-full px-4 py-1.5 text-sm font-medium border transition-colors ${
+              activeTrack.id === track.id
+                ? "border-wave/50 bg-wave/10 text-wave"
+                : "border-ink/10 text-ink/60 hover:border-ink/20 hover:text-ink"
+            }`}
+          >
+            {track.title}
+          </button>
+        ))}
+      </div>
+
+      {/* Player */}
+      <AudioWaveformPlayer
+        key={activeTrack.id}
+        url={activeTrack.url}
+        title={activeTrack.title}
+        peaks={250}
+        showRegions
+        showStylePicker
+        onRegionCreate={(r: WaveformRegion) => setRegions((prev: WaveformRegion[]) => [...prev, r])}
+      />
+
+      {/* Feature callouts */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {[
+          { icon: "🎵", title: "Waveform Generation", desc: "Decoded via Web Audio API with synthetic fallback" },
+          { icon: "🔍", title: "Zoom Controls", desc: "Up to 10× zoom with horizontal scroll" },
+          { icon: "✂️", title: "Region Selection", desc: "Drag on the waveform to mark regions" },
+          { icon: "🎨", title: "Waveform Styling", desc: "4 colour presets, customisable per instance" },
+        ].map(({ icon, title, desc }) => (
+          <div key={title} className="rounded-2xl border border-ink/10 bg-[color:var(--surface)] p-4">
+            <span className="text-2xl" aria-hidden="true">{icon}</span>
+            <p className="mt-2 font-semibold text-ink text-sm">{title}</p>
+            <p className="mt-0.5 text-xs text-ink/50">{desc}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/audio/AudioControls.tsx
+++ b/src/components/audio/AudioControls.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { Play, Pause, Volume2, VolumeX, SkipBack, SkipForward } from "lucide-react";
+import type { ChangeEvent } from "react";
+import type { AudioPlayerState } from "@/types/audio";
+
+function formatTime(seconds: number): string {
+  if (!isFinite(seconds) || isNaN(seconds)) return "0:00";
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+interface AudioControlsProps {
+  state: AudioPlayerState;
+  onTogglePlay: () => void;
+  onSeek: (time: number) => void;
+  onVolumeChange: (vol: number) => void;
+  onToggleMute: () => void;
+  onPlaybackRateChange: (rate: number) => void;
+  onSkip: (seconds: number) => void;
+  compact?: boolean;
+}
+
+const RATES = [0.5, 0.75, 1, 1.25, 1.5, 2];
+
+export function AudioControls({
+  state,
+  onTogglePlay,
+  onSeek,
+  onVolumeChange,
+  onToggleMute,
+  onPlaybackRateChange,
+  onSkip,
+  compact = false,
+}: AudioControlsProps) {
+  const progress = state.duration > 0 ? (state.currentTime / state.duration) * 100 : 0;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* Seek bar */}
+      <div className="flex items-center gap-2">
+        <span className="text-xs tabular-nums text-ink/50 w-10 text-right">
+          {formatTime(state.currentTime)}
+        </span>
+        <input
+          type="range"
+          min={0}
+          max={state.duration || 100}
+          step={0.01}
+          value={state.currentTime}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => onSeek(Number(e.target.value))}
+          className="flex-1 h-1.5 accent-wave cursor-pointer"
+          aria-label="Seek"
+        />
+        <span className="text-xs tabular-nums text-ink/50 w-10">
+          {formatTime(state.duration)}
+        </span>
+      </div>
+
+      {/* Buttons row */}
+      <div className="flex items-center gap-3">
+        {/* Skip back */}
+        <button
+          type="button"
+          onClick={() => onSkip(-10)}
+          className="text-ink/60 hover:text-ink transition-colors"
+          aria-label="Skip back 10 seconds"
+        >
+          <SkipBack className="h-4 w-4" />
+        </button>
+
+        {/* Play / Pause */}
+        <button
+          type="button"
+          onClick={onTogglePlay}
+          disabled={state.isLoading || state.isDecoding}
+          className="flex h-10 w-10 items-center justify-center rounded-full bg-wave text-white shadow-md hover:bg-wave/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          aria-label={state.isPlaying ? "Pause" : "Play"}
+        >
+          {state.isPlaying ? (
+            <Pause className="h-5 w-5" />
+          ) : (
+            <Play className="h-5 w-5 translate-x-0.5" />
+          )}
+        </button>
+
+        {/* Skip forward */}
+        <button
+          type="button"
+          onClick={() => onSkip(10)}
+          className="text-ink/60 hover:text-ink transition-colors"
+          aria-label="Skip forward 10 seconds"
+        >
+          <SkipForward className="h-4 w-4" />
+        </button>
+
+        {!compact && (
+          <>
+            {/* Playback rate */}
+            <select
+              value={state.playbackRate}
+              onChange={(e: ChangeEvent<HTMLSelectElement>) => onPlaybackRateChange(Number(e.target.value))}
+              className="ml-1 rounded-lg border border-ink/10 bg-[color:var(--surface)] px-2 py-1 text-xs text-ink focus:outline-none focus:ring-2 focus:ring-wave/40"
+              aria-label="Playback speed"
+            >
+              {RATES.map((r) => (
+                <option key={r} value={r}>
+                  {r}×
+                </option>
+              ))}
+            </select>
+
+            {/* Volume */}
+            <div className="ml-auto flex items-center gap-2">
+              <button
+                type="button"
+                onClick={onToggleMute}
+                className="text-ink/60 hover:text-ink transition-colors"
+                aria-label={state.muted ? "Unmute" : "Mute"}
+              >
+                {state.muted || state.volume === 0 ? (
+                  <VolumeX className="h-4 w-4" />
+                ) : (
+                  <Volume2 className="h-4 w-4" />
+                )}
+              </button>
+              <input
+                type="range"
+                min={0}
+                max={1}
+                step={0.05}
+                value={state.muted ? 0 : state.volume}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => onVolumeChange(Number(e.target.value))}
+                className="w-20 h-1.5 accent-wave cursor-pointer"
+                aria-label="Volume"
+              />
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/audio/AudioWaveformPlayer.tsx
+++ b/src/components/audio/AudioWaveformPlayer.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { useRef, useState, useCallback } from "react";
+import { motion } from "framer-motion";
+import { Scissors, Palette } from "lucide-react";
+import { useAudioWaveform } from "@/hooks/useAudioWaveform";
+import { WaveformCanvas } from "./WaveformCanvas";
+import { AudioControls } from "./AudioControls";
+import { ZoomControls } from "./ZoomControls";
+import { RegionList } from "./RegionList";
+import type { WaveformStyle, WaveformRegion } from "@/types/audio";
+
+const ZOOM_STEP = 0.5;
+const ZOOM_MIN = 1;
+const ZOOM_MAX = 10;
+
+const PRESET_STYLES: { label: string; style: Partial<WaveformStyle> }[] = [
+  {
+    label: "Indigo",
+    style: {
+      waveColor: "rgba(99,102,241,0.45)",
+      progressColor: "rgba(99,102,241,1)",
+      cursorColor: "#6366f1",
+      regionColor: "rgba(99,102,241,0.15)",
+    },
+  },
+  {
+    label: "Wave",
+    style: {
+      waveColor: "rgba(14,165,233,0.45)",
+      progressColor: "rgba(14,165,233,1)",
+      cursorColor: "#0ea5e9",
+      regionColor: "rgba(14,165,233,0.15)",
+    },
+  },
+  {
+    label: "Sunrise",
+    style: {
+      waveColor: "rgba(249,115,22,0.45)",
+      progressColor: "rgba(249,115,22,1)",
+      cursorColor: "#f97316",
+      regionColor: "rgba(249,115,22,0.15)",
+    },
+  },
+  {
+    label: "Moss",
+    style: {
+      waveColor: "rgba(34,197,94,0.45)",
+      progressColor: "rgba(34,197,94,1)",
+      cursorColor: "#22c55e",
+      regionColor: "rgba(34,197,94,0.15)",
+    },
+  },
+];
+
+export interface AudioWaveformPlayerProps {
+  /** URL of the audio file to load */
+  url: string;
+  /** Optional title shown above the player */
+  title?: string;
+  /** Number of waveform bars */
+  peaks?: number;
+  /** Initial style overrides */
+  styleOverride?: Partial<WaveformStyle>;
+  /** Show region selection tools */
+  showRegions?: boolean;
+  /** Show style picker */
+  showStylePicker?: boolean;
+  className?: string;
+  onRegionCreate?: (region: WaveformRegion) => void;
+}
+
+export function AudioWaveformPlayer({
+  url,
+  title,
+  peaks = 200,
+  styleOverride,
+  showRegions = true,
+  showStylePicker = true,
+  className = "",
+  onRegionCreate,
+}: AudioWaveformPlayerProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [scrollLeft, setScrollLeft] = useState(0);
+  const [activePreset, setActivePreset] = useState(0);
+  const [pendingRegionStart, setPendingRegionStart] = useState<number | null>(null);
+  const [showStylePanel, setShowStylePanel] = useState(false);
+
+  const mergedStyle: Partial<WaveformStyle> = {
+    ...PRESET_STYLES[activePreset].style,
+    ...styleOverride,
+  };
+
+  const { peaks: waveformPeaks, regions, playerState, style, actions } = useAudioWaveform({
+    url,
+    peaks,
+    style: mergedStyle,
+    onRegionCreate,
+  });
+
+  const handleZoomIn = useCallback(() => {
+    actions.setZoom(Math.min(ZOOM_MAX, playerState.zoom + ZOOM_STEP));
+  }, [actions, playerState.zoom]);
+
+  const handleZoomOut = useCallback(() => {
+    actions.setZoom(Math.max(ZOOM_MIN, playerState.zoom - ZOOM_STEP));
+  }, [actions, playerState.zoom]);
+
+  const handleScroll = useCallback(() => {
+    setScrollLeft(scrollRef.current?.scrollLeft ?? 0);
+  }, []);
+
+  const handleRegionDragEnd = useCallback(
+    (start: number, end: number) => {
+      actions.addRegion({
+        start,
+        end,
+        label: `Region ${regions.length + 1}`,
+        color: PRESET_STYLES[activePreset].style.regionColor,
+      });
+    },
+    [actions, regions.length, activePreset]
+  );
+
+  const isReady = !playerState.isLoading && !playerState.isDecoding && waveformPeaks !== null;
+
+  return (
+    <div className={`rounded-2xl border border-ink/10 bg-[color:var(--surface)] overflow-hidden ${className}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between gap-3 px-5 pt-4 pb-2">
+        <div className="min-w-0">
+          {title && (
+            <p className="font-semibold text-ink text-sm truncate">{title}</p>
+          )}
+          <p className="text-xs text-ink/40">
+            {playerState.isDecoding
+              ? "Analysing audio…"
+              : playerState.isLoading
+              ? "Loading…"
+              : playerState.error
+              ? playerState.error
+              : `${Math.floor(playerState.duration / 60)}:${String(Math.floor(playerState.duration % 60)).padStart(2, "0")} · ${peaks} bars`}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          {/* Zoom controls */}
+          <ZoomControls
+            zoom={playerState.zoom}
+            onZoomIn={handleZoomIn}
+            onZoomOut={handleZoomOut}
+            onReset={() => actions.setZoom(1)}
+            min={ZOOM_MIN}
+            max={ZOOM_MAX}
+          />
+
+          {/* Style picker toggle */}
+          {showStylePicker && (
+            <button
+              type="button"
+              onClick={() => setShowStylePanel((v: boolean) => !v)}
+              className={`flex h-7 w-7 items-center justify-center rounded-lg border transition-colors ${
+                showStylePanel
+                  ? "border-wave/50 bg-wave/10 text-wave"
+                  : "border-ink/10 bg-[color:var(--surface)] text-ink/60 hover:text-ink"
+              }`}
+              aria-label="Waveform style"
+            >
+              <Palette className="h-3.5 w-3.5" />
+            </button>
+          )}
+
+          {/* Region tool toggle */}
+          {showRegions && (
+            <button
+              type="button"
+              onClick={() => actions.clearRegions()}
+              className="flex h-7 items-center gap-1 rounded-lg border border-ink/10 bg-[color:var(--surface)] px-2 text-xs text-ink/60 hover:text-ink hover:border-ink/20 transition-colors"
+              aria-label="Clear all regions"
+            >
+              <Scissors className="h-3 w-3" />
+              Clear
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Style picker panel */}
+      {showStylePanel && (
+        <motion.div
+          initial={{ height: 0, opacity: 0 }}
+          animate={{ height: "auto", opacity: 1 }}
+          exit={{ height: 0, opacity: 0 }}
+          className="px-5 pb-3 flex items-center gap-2 flex-wrap"
+        >
+          {PRESET_STYLES.map((preset, i) => (
+            <button
+              key={preset.label}
+              type="button"
+              onClick={() => setActivePreset(i)}
+              className={`flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium border transition-colors ${
+                activePreset === i
+                  ? "border-wave/50 bg-wave/10 text-wave"
+                  : "border-ink/10 text-ink/60 hover:border-ink/20 hover:text-ink"
+              }`}
+            >
+              <span
+                className="h-2.5 w-2.5 rounded-full"
+                style={{ backgroundColor: preset.style.progressColor as string }}
+              />
+              {preset.label}
+            </button>
+          ))}
+        </motion.div>
+      )}
+
+      {/* Waveform area */}
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className="overflow-x-auto scrollbar-thin scrollbar-thumb-ink/10 scrollbar-track-transparent"
+        style={{ cursor: "default" }}
+      >
+        <div style={{ width: `${playerState.zoom * 100}%`, minWidth: "100%" }}>
+          {playerState.isDecoding || !waveformPeaks ? (
+            <div
+              className="flex items-center justify-center"
+              style={{ height: style.height }}
+            >
+              <div className="flex items-end gap-0.5">
+                {Array.from({ length: 20 }).map((_, i) => (
+                  <motion.div
+                    key={i}
+                    className="w-1.5 rounded-full bg-ink/10"
+                    animate={{ height: [8, 24 + Math.random() * 24, 8] }}
+                    transition={{
+                      duration: 0.8 + Math.random() * 0.4,
+                      repeat: Infinity,
+                      delay: i * 0.05,
+                    }}
+                  />
+                ))}
+              </div>
+            </div>
+          ) : (
+            <WaveformCanvas
+              peaks={waveformPeaks}
+              currentTime={playerState.currentTime}
+              duration={playerState.duration}
+              zoom={playerState.zoom}
+              regions={regions}
+              style={style}
+              scrollLeft={scrollLeft}
+              onSeek={actions.seek}
+              onRegionDragEnd={showRegions ? handleRegionDragEnd : undefined}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Controls */}
+      <div className="px-5 py-4 border-t border-ink/5">
+        <AudioControls
+          state={playerState}
+          onTogglePlay={actions.togglePlay}
+          onSeek={actions.seek}
+          onVolumeChange={actions.setVolume}
+          onToggleMute={actions.toggleMute}
+          onPlaybackRateChange={actions.setPlaybackRate}
+          onSkip={(s) => actions.seek(playerState.currentTime + s)}
+        />
+      </div>
+
+      {/* Region list */}
+      {showRegions && regions.length > 0 && (
+        <div className="px-5 pb-4 border-t border-ink/5 pt-3">
+          <p className="text-xs font-semibold text-ink/50 uppercase tracking-wide mb-2">
+            Regions
+          </p>
+          <RegionList
+            regions={regions}
+            onRegionClick={actions.handleRegionClick}
+            onRegionRemove={actions.removeRegion}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/audio/RegionList.tsx
+++ b/src/components/audio/RegionList.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+import type { WaveformRegion } from "@/types/audio";
+
+function formatTime(s: number): string {
+  const m = Math.floor(s / 60);
+  const sec = Math.floor(s % 60);
+  return `${m}:${sec.toString().padStart(2, "0")}`;
+}
+
+interface RegionListProps {
+  regions: WaveformRegion[];
+  onRegionClick: (region: WaveformRegion) => void;
+  onRegionRemove: (id: string) => void;
+}
+
+export function RegionList({ regions, onRegionClick, onRegionRemove }: RegionListProps) {
+  if (regions.length === 0) {
+    return (
+      <p className="text-xs text-ink/40 italic py-2">
+        Drag on the waveform to create a region
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-1.5">
+      {regions.map((region, i) => (
+        <div
+          key={region.id}
+          className="flex items-center gap-3 rounded-xl border border-ink/10 bg-[color:var(--surface)] px-3 py-2 hover:border-ink/20 transition-colors"
+        >
+          {/* Color swatch */}
+          <div
+            className="h-3 w-3 rounded-full shrink-0"
+            style={{ backgroundColor: region.color ?? "rgba(99,102,241,0.6)" }}
+          />
+
+          {/* Label + time range */}
+          <button
+            type="button"
+            onClick={() => onRegionClick(region)}
+            className="flex-1 text-left"
+          >
+            <p className="text-xs font-medium text-ink">
+              {region.label ?? `Region ${i + 1}`}
+            </p>
+            <p className="text-[10px] text-ink/50 tabular-nums">
+              {formatTime(region.start)} – {formatTime(region.end)}
+            </p>
+          </button>
+
+          {/* Remove */}
+          <button
+            type="button"
+            onClick={() => onRegionRemove(region.id)}
+            className="text-ink/30 hover:text-red-500 transition-colors"
+            aria-label={`Remove region ${region.label ?? i + 1}`}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/audio/WaveformCanvas.tsx
+++ b/src/components/audio/WaveformCanvas.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import type { PointerEvent as ReactPointerEvent } from "react";
+import type { WaveformRegion, WaveformStyle } from "@/types/audio";
+
+interface WaveformCanvasProps {
+  peaks: Float32Array;
+  currentTime: number;
+  duration: number;
+  zoom: number;
+  regions: WaveformRegion[];
+  style: WaveformStyle;
+  /** Scroll offset in pixels (for zoom > 1) */
+  scrollLeft?: number;
+  onSeek?: (time: number) => void;
+  onRegionDragStart?: (startTime: number) => void;
+  onRegionDragEnd?: (startTime: number, endTime: number) => void;
+  className?: string;
+}
+
+export function WaveformCanvas({
+  peaks,
+  currentTime,
+  duration,
+  zoom,
+  regions,
+  style,
+  scrollLeft = 0,
+  onSeek,
+  onRegionDragStart,
+  onRegionDragEnd,
+  className = "",
+}: WaveformCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const dragStartRef = useRef<number | null>(null);
+  const isDraggingRef = useRef(false);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !peaks.length) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const width = canvas.offsetWidth;
+    const height = style.height;
+
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    canvas.style.height = `${height}px`;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.scale(dpr, dpr);
+
+    const totalWidth = width * zoom;
+    const visibleStart = scrollLeft;
+    const visibleEnd = scrollLeft + width;
+
+    // Background
+    if (style.backgroundColor !== "transparent") {
+      ctx.fillStyle = style.backgroundColor;
+      ctx.fillRect(0, 0, width, height);
+    } else {
+      ctx.clearRect(0, 0, width, height);
+    }
+
+    const barTotal = style.barWidth + style.barGap;
+    const numBars = Math.floor(totalWidth / barTotal);
+    const peaksPerBar = peaks.length / numBars;
+    const centerY = height / 2;
+
+    // Draw regions
+    for (const region of regions) {
+      if (duration <= 0) continue;
+      const rStart = (region.start / duration) * totalWidth - visibleStart;
+      const rEnd = (region.end / duration) * totalWidth - visibleStart;
+      if (rEnd < 0 || rStart > width) continue;
+
+      ctx.fillStyle = region.color ?? style.regionColor;
+      ctx.fillRect(
+        Math.max(0, rStart),
+        0,
+        Math.min(width, rEnd) - Math.max(0, rStart),
+        height
+      );
+
+      // Region label
+      if (region.label) {
+        ctx.fillStyle = style.progressColor;
+        ctx.font = "10px sans-serif";
+        ctx.fillText(region.label, Math.max(4, rStart + 4), 14);
+      }
+    }
+
+    // Draw bars
+    const progressX = duration > 0 ? (currentTime / duration) * totalWidth - visibleStart : 0;
+
+    for (let i = 0; i < numBars; i++) {
+      const barX = i * barTotal - visibleStart;
+      if (barX + style.barWidth < 0 || barX > width) continue;
+
+      // Average peaks for this bar
+      const peakStart = Math.floor(i * peaksPerBar);
+      const peakEnd = Math.min(peaks.length, Math.ceil((i + 1) * peaksPerBar));
+      let amp = 0;
+      for (let p = peakStart; p < peakEnd; p++) amp += peaks[p];
+      amp /= peakEnd - peakStart || 1;
+
+      const barHeight = Math.max(2, amp * (height * 0.85));
+      const y = centerY - barHeight / 2;
+
+      // Color: progress vs unplayed
+      ctx.fillStyle = barX < progressX ? style.progressColor : style.waveColor;
+
+      if (style.barRadius > 0) {
+        roundRect(ctx, barX, y, style.barWidth, barHeight, style.barRadius);
+        ctx.fill();
+      } else {
+        ctx.fillRect(barX, y, style.barWidth, barHeight);
+      }
+    }
+
+    // Cursor line
+    if (progressX >= 0 && progressX <= width) {
+      ctx.strokeStyle = style.cursorColor;
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(progressX, 0);
+      ctx.lineTo(progressX, height);
+      ctx.stroke();
+    }
+  }, [peaks, currentTime, duration, zoom, regions, style, scrollLeft]);
+
+  useEffect(() => {
+    draw();
+  }, [draw]);
+
+  // Resize observer
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ro = new ResizeObserver(() => draw());
+    ro.observe(canvas);
+    return () => ro.disconnect();
+  }, [draw]);
+
+  const timeFromX = useCallback(
+    (clientX: number): number => {
+      const canvas = canvasRef.current;
+      if (!canvas || duration <= 0) return 0;
+      const rect = canvas.getBoundingClientRect();
+      const x = clientX - rect.left + scrollLeft;
+      return Math.max(0, Math.min(duration, (x / (canvas.offsetWidth * zoom)) * duration));
+    },
+    [duration, zoom, scrollLeft]
+  );
+
+  const handlePointerDown = useCallback(
+    (e: ReactPointerEvent<HTMLCanvasElement>) => {
+      e.currentTarget.setPointerCapture(e.pointerId);
+      const t = timeFromX(e.clientX);
+      dragStartRef.current = t;
+      isDraggingRef.current = false;
+      onSeek?.(t);
+      onRegionDragStart?.(t);
+    },
+    [timeFromX, onSeek, onRegionDragStart]
+  );
+
+  const handlePointerMove = useCallback(
+    (e: ReactPointerEvent<HTMLCanvasElement>) => {
+      if (dragStartRef.current === null) return;
+      isDraggingRef.current = true;
+      onSeek?.(timeFromX(e.clientX));
+    },
+    [timeFromX, onSeek]
+  );
+
+  const handlePointerUp = useCallback(
+    (e: ReactPointerEvent<HTMLCanvasElement>) => {
+      if (dragStartRef.current !== null && isDraggingRef.current) {
+        const endTime = timeFromX(e.clientX);
+        const startTime = dragStartRef.current;
+        if (Math.abs(endTime - startTime) > 0.1) {
+          onRegionDragEnd?.(
+            Math.min(startTime, endTime),
+            Math.max(startTime, endTime)
+          );
+        }
+      }
+      dragStartRef.current = null;
+      isDraggingRef.current = false;
+    },
+    [timeFromX, onRegionDragEnd]
+  );
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={`w-full cursor-pointer select-none touch-none ${className}`}
+      style={{ height: style.height }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      aria-label="Audio waveform — click to seek"
+      role="slider"
+      aria-valuemin={0}
+      aria-valuemax={duration}
+      aria-valuenow={currentTime}
+    />
+  );
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function roundRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number
+) {
+  const radius = Math.min(r, w / 2, h / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.lineTo(x + w - radius, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + radius);
+  ctx.lineTo(x + w, y + h - radius);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - radius, y + h);
+  ctx.lineTo(x + radius, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - radius);
+  ctx.lineTo(x, y + radius);
+  ctx.quadraticCurveTo(x, y, x + radius, y);
+  ctx.closePath();
+}

--- a/src/components/audio/ZoomControls.tsx
+++ b/src/components/audio/ZoomControls.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { ZoomIn, ZoomOut, Maximize2 } from "lucide-react";
+
+interface ZoomControlsProps {
+  zoom: number;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onReset: () => void;
+  min?: number;
+  max?: number;
+}
+
+export function ZoomControls({
+  zoom,
+  onZoomIn,
+  onZoomOut,
+  onReset,
+  min = 1,
+  max = 10,
+}: ZoomControlsProps) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <button
+        type="button"
+        onClick={onZoomOut}
+        disabled={zoom <= min}
+        className="flex h-7 w-7 items-center justify-center rounded-lg border border-ink/10 bg-[color:var(--surface)] text-ink/60 hover:text-ink hover:border-ink/20 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+        aria-label="Zoom out"
+      >
+        <ZoomOut className="h-3.5 w-3.5" />
+      </button>
+
+      <span className="min-w-[3rem] text-center text-xs font-medium text-ink/60 tabular-nums">
+        {zoom.toFixed(1)}×
+      </span>
+
+      <button
+        type="button"
+        onClick={onZoomIn}
+        disabled={zoom >= max}
+        className="flex h-7 w-7 items-center justify-center rounded-lg border border-ink/10 bg-[color:var(--surface)] text-ink/60 hover:text-ink hover:border-ink/20 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+        aria-label="Zoom in"
+      >
+        <ZoomIn className="h-3.5 w-3.5" />
+      </button>
+
+      <button
+        type="button"
+        onClick={onReset}
+        disabled={zoom === 1}
+        className="flex h-7 w-7 items-center justify-center rounded-lg border border-ink/10 bg-[color:var(--surface)] text-ink/60 hover:text-ink hover:border-ink/20 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+        aria-label="Reset zoom"
+      >
+        <Maximize2 className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/audio/index.ts
+++ b/src/components/audio/index.ts
@@ -1,0 +1,5 @@
+export { AudioWaveformPlayer } from "./AudioWaveformPlayer";
+export { WaveformCanvas } from "./WaveformCanvas";
+export { AudioControls } from "./AudioControls";
+export { ZoomControls } from "./ZoomControls";
+export { RegionList } from "./RegionList";

--- a/src/hooks/useAudioWaveform.ts
+++ b/src/hooks/useAudioWaveform.ts
@@ -1,0 +1,277 @@
+"use client";
+
+import { useState, useRef, useCallback, useEffect } from "react";
+import type {
+  AudioPlayerState,
+  WaveformRegion,
+  UseAudioWaveformOptions,
+  WaveformStyle,
+} from "@/types/audio";
+
+export const DEFAULT_STYLE: WaveformStyle = {
+  waveColor: "rgba(99,102,241,0.5)",
+  progressColor: "rgba(99,102,241,1)",
+  backgroundColor: "transparent",
+  regionColor: "rgba(99,102,241,0.15)",
+  cursorColor: "#6366f1",
+  barWidth: 3,
+  barGap: 1,
+  barRadius: 2,
+  height: 80,
+};
+
+/** Decode an audio file URL into a Float32Array of normalised peak amplitudes. */
+async function decodePeaks(url: string, numPeaks: number): Promise<Float32Array> {
+  const AudioCtx =
+    window.AudioContext ||
+    (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!AudioCtx) throw new Error("Web Audio API not supported");
+
+  const ctx = new AudioCtx();
+  try {
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`Failed to fetch audio: ${response.status}`);
+    const arrayBuffer = await response.arrayBuffer();
+    const audioBuffer = await ctx.decodeAudioData(arrayBuffer);
+
+    const channelData = audioBuffer.getChannelData(0);
+    const blockSize = Math.floor(channelData.length / numPeaks);
+    const peaks = new Float32Array(numPeaks);
+
+    for (let i = 0; i < numPeaks; i++) {
+      let max = 0;
+      const start = i * blockSize;
+      const end = start + blockSize;
+      for (let j = start; j < end; j++) {
+        const abs = Math.abs(channelData[j]);
+        if (abs > max) max = abs;
+      }
+      peaks[i] = max;
+    }
+
+    // Normalise to 0–1
+    const globalMax = Math.max(...Array.from(peaks));
+    if (globalMax > 0) {
+      for (let i = 0; i < peaks.length; i++) peaks[i] /= globalMax;
+    }
+
+    return peaks;
+  } finally {
+    await ctx.close();
+  }
+}
+
+/** Generate synthetic peaks for demo/fallback when real audio can't be decoded. */
+function generateSyntheticPeaks(numPeaks: number): Float32Array {
+  const peaks = new Float32Array(numPeaks);
+  for (let i = 0; i < numPeaks; i++) {
+    // Smooth random walk with some structure
+    const t = i / numPeaks;
+    const base = 0.3 + 0.4 * Math.sin(t * Math.PI * 6);
+    const noise = (Math.random() - 0.5) * 0.3;
+    peaks[i] = Math.max(0.05, Math.min(1, base + noise));
+  }
+  return peaks;
+}
+
+export function useAudioWaveform(options: UseAudioWaveformOptions) {
+  const {
+    url,
+    peaks: numPeaks = 200,
+    style: styleOverride,
+    onReady,
+    onTimeUpdate,
+    onRegionCreate,
+    onRegionClick,
+  } = options;
+
+  const style: WaveformStyle = { ...DEFAULT_STYLE, ...styleOverride };
+
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const animFrameRef = useRef<number | null>(null);
+
+  const [peaks, setPeaks] = useState<Float32Array | null>(null);
+  const [regions, setRegions] = useState<WaveformRegion[]>([]);
+  const [playerState, setPlayerState] = useState<AudioPlayerState>({
+    isPlaying: false,
+    currentTime: 0,
+    duration: 0,
+    volume: 1,
+    muted: false,
+    playbackRate: 1,
+    zoom: 1,
+    isLoading: true,
+    isDecoding: true,
+    error: null,
+  });
+
+  // ── Decode peaks on mount / url change ──────────────────────────────────
+  useEffect(() => {
+    let cancelled = false;
+    setPlayerState((p) => ({ ...p, isLoading: true, isDecoding: true, error: null }));
+
+    decodePeaks(url, numPeaks)
+      .then((decoded) => {
+        if (!cancelled) {
+          setPeaks(decoded);
+          setPlayerState((p) => ({ ...p, isDecoding: false }));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          // Fallback to synthetic peaks so the UI still renders
+          setPeaks(generateSyntheticPeaks(numPeaks));
+          setPlayerState((p) => ({ ...p, isDecoding: false }));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [url, numPeaks]);
+
+  // ── Wire up HTMLAudioElement ─────────────────────────────────────────────
+  useEffect(() => {
+    const audio = new Audio(url);
+    audio.preload = "metadata";
+    audioRef.current = audio;
+
+    const onLoadedMetadata = () => {
+      setPlayerState((p) => ({ ...p, duration: audio.duration, isLoading: false }));
+      onReady?.(audio.duration);
+    };
+    const onEnded = () => setPlayerState((p) => ({ ...p, isPlaying: false }));
+    const onError = () =>
+      setPlayerState((p) => ({ ...p, error: "Failed to load audio", isLoading: false }));
+
+    audio.addEventListener("loadedmetadata", onLoadedMetadata);
+    audio.addEventListener("ended", onEnded);
+    audio.addEventListener("error", onError);
+
+    return () => {
+      audio.pause();
+      audio.removeEventListener("loadedmetadata", onLoadedMetadata);
+      audio.removeEventListener("ended", onEnded);
+      audio.removeEventListener("error", onError);
+      audioRef.current = null;
+    };
+  }, [url, onReady]);
+
+  // ── Playback time tracking via rAF ───────────────────────────────────────
+  useEffect(() => {
+    if (!playerState.isPlaying) {
+      if (animFrameRef.current) cancelAnimationFrame(animFrameRef.current);
+      return;
+    }
+
+    const tick = () => {
+      const audio = audioRef.current;
+      if (!audio) return;
+      const t = audio.currentTime;
+      setPlayerState((p) => ({ ...p, currentTime: t }));
+      onTimeUpdate?.(t);
+      animFrameRef.current = requestAnimationFrame(tick);
+    };
+    animFrameRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      if (animFrameRef.current) cancelAnimationFrame(animFrameRef.current);
+    };
+  }, [playerState.isPlaying, onTimeUpdate]);
+
+  // ── Actions ──────────────────────────────────────────────────────────────
+
+  const play = useCallback(() => {
+    audioRef.current?.play().then(() => {
+      setPlayerState((p) => ({ ...p, isPlaying: true }));
+    }).catch(() => {});
+  }, []);
+
+  const pause = useCallback(() => {
+    audioRef.current?.pause();
+    setPlayerState((p) => ({ ...p, isPlaying: false }));
+  }, []);
+
+  const togglePlay = useCallback(() => {
+    if (playerState.isPlaying) pause();
+    else play();
+  }, [playerState.isPlaying, play, pause]);
+
+  const seek = useCallback((time: number) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const clamped = Math.max(0, Math.min(audio.duration || 0, time));
+    audio.currentTime = clamped;
+    setPlayerState((p) => ({ ...p, currentTime: clamped }));
+  }, []);
+
+  const setVolume = useCallback((vol: number) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const clamped = Math.max(0, Math.min(1, vol));
+    audio.volume = clamped;
+    setPlayerState((p) => ({ ...p, volume: clamped, muted: clamped === 0 }));
+  }, []);
+
+  const toggleMute = useCallback(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.muted = !audio.muted;
+    setPlayerState((p) => ({ ...p, muted: audio.muted }));
+  }, []);
+
+  const setPlaybackRate = useCallback((rate: number) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.playbackRate = rate;
+    setPlayerState((p) => ({ ...p, playbackRate: rate }));
+  }, []);
+
+  const setZoom = useCallback((zoom: number) => {
+    setPlayerState((p) => ({ ...p, zoom: Math.max(1, Math.min(10, zoom)) }));
+  }, []);
+
+  const addRegion = useCallback(
+    (region: Omit<WaveformRegion, "id">) => {
+      const newRegion: WaveformRegion = { ...region, id: `region-${Date.now()}` };
+      setRegions((prev) => [...prev, newRegion]);
+      onRegionCreate?.(newRegion);
+    },
+    [onRegionCreate]
+  );
+
+  const removeRegion = useCallback((id: string) => {
+    setRegions((prev) => prev.filter((r) => r.id !== id));
+  }, []);
+
+  const clearRegions = useCallback(() => setRegions([]), []);
+
+  const handleRegionClick = useCallback(
+    (region: WaveformRegion) => {
+      seek(region.start);
+      onRegionClick?.(region);
+    },
+    [seek, onRegionClick]
+  );
+
+  return {
+    peaks,
+    regions,
+    playerState,
+    style,
+    actions: {
+      play,
+      pause,
+      togglePlay,
+      seek,
+      setVolume,
+      toggleMute,
+      setPlaybackRate,
+      setZoom,
+      addRegion,
+      removeRegion,
+      clearRegions,
+      handleRegionClick,
+    },
+  };
+}

--- a/src/types/audio.ts
+++ b/src/types/audio.ts
@@ -1,0 +1,45 @@
+// ── Audio waveform types ───────────────────────────────────────────────────
+
+export interface WaveformRegion {
+  id: string;
+  start: number; // seconds
+  end: number;   // seconds
+  label?: string;
+  color?: string;
+}
+
+export interface WaveformStyle {
+  waveColor: string;
+  progressColor: string;
+  backgroundColor: string;
+  regionColor: string;
+  cursorColor: string;
+  barWidth: number;
+  barGap: number;
+  barRadius: number;
+  height: number;
+}
+
+export interface AudioPlayerState {
+  isPlaying: boolean;
+  currentTime: number;
+  duration: number;
+  volume: number;
+  muted: boolean;
+  playbackRate: number;
+  zoom: number;
+  isLoading: boolean;
+  isDecoding: boolean;
+  error: string | null;
+}
+
+export interface UseAudioWaveformOptions {
+  url: string;
+  /** Number of waveform bars to render */
+  peaks?: number;
+  style?: Partial<WaveformStyle>;
+  onReady?: (duration: number) => void;
+  onTimeUpdate?: (time: number) => void;
+  onRegionCreate?: (region: WaveformRegion) => void;
+  onRegionClick?: (region: WaveformRegion) => void;
+}


### PR DESCRIPTION
- Add src/types/audio.ts with WaveformRegion, WaveformStyle, AudioPlayerState types
- Add useAudioWaveform hook: Web Audio API peak decoding, synthetic fallback, HTMLAudioElement playback, rAF time tracking, region management, zoom state
- Add WaveformCanvas: canvas-based bar renderer with progress coloring, region overlays, cursor line, pointer drag-to-seek and drag-to-create-region
- Add AudioControls: play/pause, seek bar, skip ±10s, playback rate selector, volume + mute
- Add ZoomControls: zoom in/out/reset with min/max guards
- Add RegionList: clickable region entries with remove button
- Add AudioWaveformPlayer: full player combining all sub-components, 4 color presets, style picker panel, animated loading skeleton
- Add /audio demo page with track switcher and feature callouts
closes #373