### PR TITLE
feat: add in-app notification center panel

### DIFF
--- a/src/components/NotificationBadge.tsx
+++ b/src/components/NotificationBadge.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 import { useWebSocketContext } from "@/contexts/WebSocketContext";
-import { useNotificationStore } from "@/store/notificationStore";
+import { useNotificationStore, useUnreadCount } from "@/store/notificationStore";
 
 /** Bell SVG icon */
 function BellIcon({ className }: { className?: string }) {
@@ -68,8 +68,9 @@ function SoundIcon({
 }
 
 export function NotificationBadge() {
-  const { unreadCount, markAllRead, isMuted, setMuted } = useWebSocketContext();
+  const { isMuted, setMuted } = useWebSocketContext();
   const { setOpen } = useNotificationStore();
+  const unreadCount = useUnreadCount();
 
   const handleBellClick = useCallback(() => {
     setOpen(true);

--- a/src/components/NotificationCenter.tsx
+++ b/src/components/NotificationCenter.tsx
@@ -168,10 +168,10 @@ export function NotificationCenter() {
             animate={{ opacity: 1, x: 0 }}
             exit={{ opacity: 0, x: 400 }}
             transition={{ type: "spring", damping: 20, stiffness: 300 }}
-            className="fixed right-0 top-16 z-50 h-[calc(100vh-64px)] w-full max-w-sm overflow-hidden rounded-l-2xl border-l border-ink/10 bg-[color:var(--surface)] shadow-xl dark:border-canvas/10"
+            className="fixed right-0 top-16 z-50 flex flex-col h-[calc(100vh-64px)] w-full max-w-sm overflow-hidden rounded-l-2xl border-l border-ink/10 bg-[color:var(--surface)] shadow-xl dark:border-canvas/10"
           >
             {/* Header */}
-            <div className="flex items-center justify-between border-b border-ink/10 px-4 py-4 dark:border-canvas/10">
+            <div className="flex-shrink-0 flex items-center justify-between border-b border-ink/10 px-4 py-4 dark:border-canvas/10">
               <h2 className="text-lg font-semibold text-ink dark:text-canvas">
                 Notifications
               </h2>
@@ -187,7 +187,7 @@ export function NotificationCenter() {
 
             {/* Actions */}
             {hasNotifications && (
-              <div className="flex gap-2 border-b border-ink/10 px-4 py-3 dark:border-canvas/10">
+              <div className="flex-shrink-0 flex gap-2 border-b border-ink/10 px-4 py-3 dark:border-canvas/10">
                 <button
                   onClick={() => markAllAsRead()}
                   disabled={unreadCount === 0}
@@ -198,7 +198,7 @@ export function NotificationCenter() {
                 </button>
                 <button
                   onClick={() => clearAll()}
-                  className="flex-1 flex items-center justify-center gap-1.5 rounded-lg bg-error/5 px-3 py-2 text-xs font-semibold text-error hover:bg-error/10 transition-colors"
+                  className="flex-1 flex items-center justify-center gap-1.5 rounded-lg bg-semantic-error/10 px-3 py-2 text-xs font-semibold text-semantic-error hover:bg-semantic-error/20 transition-colors"
                 >
                   <TrashIcon className="h-4 w-4" />
                   Clear All
@@ -207,7 +207,7 @@ export function NotificationCenter() {
             )}
 
             {/* Notifications List */}
-            <div className="overflow-y-auto h-[calc(100%-128px)]">
+            <div className="flex-1 overflow-y-auto min-h-0">
               {!hasNotifications ? (
                 <div className="flex h-full items-center justify-center p-6 text-center">
                   <div>

--- a/src/contexts/WebSocketContext.tsx
+++ b/src/contexts/WebSocketContext.tsx
@@ -11,6 +11,7 @@ import React, {
 
 import { useWebSocket } from "@/hooks/useWebSocket";
 import { useNotifications, TipNotification } from "@/hooks/useNotifications";
+import { useNotificationStore } from "@/store/notificationStore";
 import { useToast } from "@/hooks/useToast";
 import { playNotificationSound, isSoundMuted, setSoundMuted } from "@/utils/soundUtils";
 import type { Tip } from "@/lib/websocket/client";
@@ -32,6 +33,7 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
   const { clientRef, status } = useWebSocket({ url: wsUrl });
   const { notifications, unreadCount, addNotification, markAllRead, clearNotifications } =
     useNotifications();
+  const { addNotification: addToStore } = useNotificationStore();
   const toast = useToast();
 
   const [isMuted, setIsMuted] = useState<boolean>(() =>
@@ -62,6 +64,16 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
 
       addNotification({ amount: String(tip.amount), from: tip.sender_address, memo: tip.memo });
 
+      // Also persist into the notification center store so the panel stays in sync
+      addToStore({
+        type: "tip",
+        title: "New tip received!",
+        description: tip.memo
+          ? `${tip.amount} XLM — "${tip.memo}"`
+          : `${tip.amount} XLM from ${shortFrom}`,
+        link: "/tips",
+      });
+
       const message = tip.memo
         ? `💸 New tip: ${tip.amount} XLM — "${tip.memo}"`
         : `💸 New tip: ${tip.amount} XLM from ${shortFrom}`;
@@ -85,7 +97,7 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
     return () => {
       client.unsubscribe(channel, handleTip);
     };
-  }, [status, clientRef, addNotification, toast, isMuted]);
+  }, [status, clientRef, addNotification, addToStore, toast, isMuted]);
 
   return (
     <WebSocketContext.Provider


### PR DESCRIPTION
Overview
This PR delivers the in-app notification center. The NotificationCenter slide-out panel, notificationStore (Zustand + localStorage persistence), and the bell trigger in NotificationBadge were scaffolded earlier but were not wired together correctly — the badge count was disconnected from the panel, the panel scroll layout was broken, and a CSS color reference was invalid. This PR fixes all of that and ships the feature end-to-end.

What changed and why
NotificationBadge.tsx
Problem: The badge count on the bell icon was reading unreadCount from WebSocketContext, which is backed by a plain useState in the useNotifications hook. That state is ephemeral — it resets to zero on every page load. The notification panel is backed by a completely separate Zustand store (notificationStore) that persists to localStorage. The two were never in sync, so the badge would show 0 even when the panel had unread items after a reload.

Fix: Replaced the WebSocketContext source with useUnreadCount — the reactive Zustand selector exported from notificationStore. The badge now reflects the same data the panel displays, survives page reloads, and updates reactively on every add/read/clear.

- const { unreadCount, markAllRead, isMuted, setMuted } = useWebSocketContext();
- const { setOpen } = useNotificationStore();
+ const { isMuted, setMuted } = useWebSocketContext();
+ const { setOpen } = useNotificationStore();
+ const unreadCount = useUnreadCount();
WebSocketContext.tsx
Problem: When a tip arrived over the WebSocket, it was only added to the local useNotifications hook state (used for the legacy live-feed). It was never written to notificationStore, so real-time tips never appeared in the notification panel and never incremented the badge.

Fix: On each incoming tip, addToStore is now also called to push a structured Notification object (type: "tip", title, description, link: "/tips") into the persisted store. The panel and badge now reflect live tips immediately.

+ const { addNotification: addToStore } = useNotificationStore();

  const handleTip = (tip: Tip) => {
    addNotification({ ... });           // existing live-feed (unchanged)
+   addToStore({                        // new: persisted notification center
+     type: "tip",
+     title: "New tip received!",
+     description: tip.memo ? `...` : `...`,
+     link: "/tips",
+   });
    toast.success(...);
  };
NotificationCenter.tsx
Problem 1 — Broken scroll layout: The scrollable notifications list used h-[calc(100%-128px)] — a hardcoded subtraction assuming the header (64px) and actions bar (64px) always occupied exactly 128px. When the panel has no notifications, the actions bar is hidden and only the header renders (~65px total), so the list element was significantly oversized and the empty state was misaligned.

Fix: Converted the panel to a proper flex column layout. The header and actions bar use flex-shrink-0, the scroll container uses flex-1 min-h-0. This makes the scroll area fill exactly the remaining space regardless of which sections are rendered.

- className="fixed right-0 top-16 z-50 h-[calc(100vh-64px)] w-full max-w-sm overflow-hidden ..."
+ className="fixed right-0 top-16 z-50 flex flex-col h-[calc(100vh-64px)] w-full max-w-sm overflow-hidden ..."

- <div className="flex items-center justify-between border-b ...">
+ <div className="flex-shrink-0 flex items-center justify-between border-b ...">

- <div className="flex gap-2 border-b ...">
+ <div className="flex-shrink-0 flex gap-2 border-b ...">

- <div className="overflow-y-auto h-[calc(100%-128px)]">
+ <div className="flex-1 overflow-y-auto min-h-0">
Problem 2 — Invalid CSS color class: The "Clear All" button used bg-error/5 and text-error. The Tailwind config defines this color under the semantic namespace (semantic.error: #ef4444), not as a top-level error key. Tailwind generated no utility classes for those names, so the button rendered with no background or text color.

Fix: Updated to the correct namespace — bg-semantic-error/10 text-semantic-error hover:bg-semantic-error/20.

- className="... bg-error/5 text-error hover:bg-error/10 ..."
+ className="... bg-semantic-error/10 text-semantic-error hover:bg-semantic-error/20 ..."
Feature checklist
Requirement	Status
Clicking NotificationBadge opens slide-out panel	✅
Notifications grouped by Today / This Week / Earlier	✅
Mark individual notification as read (click row)	✅
Mark all as read	✅
Delete individual notification (hover trash icon)	✅
Clear all notifications	✅
Tip received, new follower, milestone types supported	✅
Empty state with descriptive message	✅
Each notification links to the relevant page	✅
Badge count persists across page reloads	✅
Live WebSocket tips appear in panel in real time	✅
Spring animation slide-in from right	✅
Click-outside / overlay closes panel	✅
Dark mode support	✅
Files changed
File	Change
NotificationBadge.tsx
Badge count source → notificationStore
WebSocketContext.tsx
WebSocket tips → also written to notificationStore
NotificationCenter.tsx
Flex layout fix, semantic color fix

closes #482 