### PR TITLE
fix: persist dark mode preference and detect system theme

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -18,6 +18,7 @@ import { ToastProvider } from "@/contexts/ToastContext";
 import { ToastContainer } from "@/components/Toast";
 import { Footer } from "@/components/Footer";
 import { ProductTour } from "@/components/ProductTour";
+import { ThemeProvider } from "@/contexts/ThemeContext";
 import "@/styles/globals.css";
 
 export default async function LocaleLayout({
@@ -39,9 +40,29 @@ export default async function LocaleLayout({
 
   return (
     <html lang={locale} suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                try {
+                  var theme = localStorage.getItem('stellar-tipjar-theme');
+                  if (!theme) {
+                    theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                  }
+                  if (theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+                    document.documentElement.classList.add('dark');
+                  }
+                } catch (e) {}
+              })();
+            `,
+          }}
+        />
+      </head>
       <body>
         <SkipToContent />
         <PerformanceMonitor />
+        <ThemeProvider>
         <CurrencyProvider>
         <WalletProvider>
           <ReactQueryProvider>
@@ -68,6 +89,7 @@ export default async function LocaleLayout({
           </ReactQueryProvider>
         </WalletProvider>
         </CurrencyProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -6,6 +6,8 @@ import { useEffect, useState } from 'react';
 export type Theme = 'light' | 'dark' | 'system';
 type ResolvedTheme = 'light' | 'dark';
 
+const themeCycle: Theme[] = ['light', 'dark', 'system'];
+
 export interface UseThemeReturn {
   theme: Theme;
   resolvedTheme: ResolvedTheme | undefined;
@@ -24,11 +26,10 @@ export function useTheme(): UseThemeReturn {
   }, []);
 
   const toggleTheme = () => {
-    if (resolvedTheme === 'dark') {
-      setTheme('light');
-    } else {
-      setTheme('dark');
-    }
+    const currentTheme = (theme as Theme) || 'system';
+    const currentIndex = themeCycle.indexOf(currentTheme);
+    const nextIndex = (currentIndex + 1) % themeCycle.length;
+    setTheme(themeCycle[nextIndex]);
   };
 
   return {


### PR DESCRIPTION
## Description

This PR addresses issue #465 by implementing dark mode persistence and system preference detection for the theme toggle.

### Changes Made

1. **Added ThemeProvider to layout** (\src/app/[locale]/layout.tsx\)
   - Wrapped the app with \ThemeProvider\ from \
ext-themes\ (via \@/contexts/ThemeContext\)
   - Added inline anti-flash script in \<head>\ that reads \localStorage('stellar-tipjar-theme')\ and applies the \dark\ class before React hydration to prevent flash of unstyled content
   - Falls back to \prefers-color-scheme\ media query when no saved preference exists

2. **Updated useTheme hook** (\src/hooks/useTheme.ts\)
   - Changed \	oggleTheme\ to cycle through three states: \light → dark → system → light\
   - Previously only toggled between light and dark
   - Now respects the 'system' option which follows OS preference

### Requirements Fulfilled

- ✅ Read \prefers-color-scheme\ on first load as default
- ✅ Persist manual overrides in localStorage
- ✅ Apply theme before paint to avoid flash (inline script in \<head>\)
- ✅ ThemeToggle shows current state (sun/moon/system icons)
- ✅ 'System' option added alongside Light and Dark

Closes #465