### PR TITLE
feat: add profile completion indicator

### DIFF
--- a/src/__tests__/profileCompletion.test.ts
+++ b/src/__tests__/profileCompletion.test.ts
@@ -5,9 +5,8 @@ describe("Profile Completion Store", () => {
   beforeEach(() => {
     // Clear store before each test
     const store = useProfileCompletionStore.getState();
-    store.setFields(
-      store.getIncompleteFields().map((f) => ({ ...f, filled: false })),
-    );
+    store.clearDismissedItems();
+    store.resetFields();
   });
 
   it("should calculate completion percentage correctly", () => {

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -5,6 +5,8 @@ import { motion } from "framer-motion";
 import { UserCircleIcon, ArrowLeftIcon } from "@heroicons/react/24/outline";
 import { AvatarUpload } from "@/components/profile/AvatarUpload";
 import { ProfileForm } from "@/components/profile/ProfileForm";
+import { useProfileDetailsStore } from "@/store/profileDetailsStore";
+import { useUserStore } from "@/store/userStore";
 
 // Stub: replace with real API calls
 async function uploadAvatar(file: File): Promise<string> {
@@ -12,14 +14,43 @@ async function uploadAvatar(file: File): Promise<string> {
   return URL.createObjectURL(file);
 }
 
-async function saveProfile(values: Record<string, unknown>): Promise<void> {
-  await new Promise((r) => setTimeout(r, 600));
-  console.log("Profile saved", values);
-}
-
-const fadeUp = { initial: { opacity: 0, y: 16 }, animate: { opacity: 1, y: 0 } };
+const fadeUp = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0 },
+};
 
 export default function ProfilePage() {
+  const { profile, updateProfile, setAvatarUrl } = useProfileDetailsStore();
+  const updateUser = useUserStore((state) => state.updateUser);
+
+  async function handleAvatarUpload(file: File): Promise<string> {
+    const url = await uploadAvatar(file);
+    setAvatarUrl(url);
+    updateUser({ avatarUrl: url });
+    return url;
+  }
+
+  async function handleSaveProfile(
+    values: Record<string, unknown>,
+  ): Promise<void> {
+    await new Promise((r) => setTimeout(r, 600));
+    const tags = String(values.tags ?? "")
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+
+    updateProfile({
+      displayName: String(values.displayName ?? ""),
+      username: String(values.username ?? ""),
+      bio: String(values.bio ?? ""),
+      tags,
+      website: String(values.website ?? ""),
+      twitter: String(values.twitter ?? ""),
+      github: String(values.github ?? ""),
+    });
+    updateUser({ displayName: String(values.displayName ?? "") });
+  }
+
   return (
     <div className="min-h-screen bg-gradient-to-b from-ink/5 to-transparent">
       <div className="max-w-3xl mx-auto px-4 py-8 sm:px-6">
@@ -48,11 +79,17 @@ export default function ProfilePage() {
             transition={{ delay: 0.05 }}
             className="rounded-2xl border border-ink/10 bg-[color:var(--surface)] p-6"
           >
-            <h2 className="text-base font-semibold text-ink mb-4">Profile photo</h2>
+            <h2 className="text-base font-semibold text-ink mb-4">
+              Profile photo
+            </h2>
             <AvatarUpload
-              name="Creator"
-              onUpload={uploadAvatar}
-              onRemove={() => console.log("Avatar removed")}
+              currentSrc={profile.avatarUrl}
+              name={profile.displayName || "Creator"}
+              onUpload={handleAvatarUpload}
+              onRemove={() => {
+                setAvatarUrl(undefined);
+                updateUser({ avatarUrl: undefined });
+              }}
             />
           </motion.section>
 
@@ -62,8 +99,16 @@ export default function ProfilePage() {
             transition={{ delay: 0.1 }}
             className="rounded-2xl border border-ink/10 bg-[color:var(--surface)] p-6"
           >
-            <h2 className="text-base font-semibold text-ink mb-4">Profile information</h2>
-            <ProfileForm onSave={saveProfile} />
+            <h2 className="text-base font-semibold text-ink mb-4">
+              Profile information
+            </h2>
+            <ProfileForm
+              initialValues={{
+                ...profile,
+                tags: profile.tags.join(", "),
+              }}
+              onSave={handleSaveProfile}
+            />
           </motion.section>
         </div>
       </div>

--- a/src/components/ProfileCompletionIndicator.tsx
+++ b/src/components/ProfileCompletionIndicator.tsx
@@ -5,24 +5,24 @@ import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   ChevronDownIcon,
-  CheckCircleIcon,
+  SparklesIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
 import { ProgressBar } from "@/components/Progress/ProgressBar";
 import {
   useCompletionPercentage,
-  useIncompleteFields,
+  useVisibleProfileFields,
   useProfileCompletionStore,
 } from "@/store/profileCompletionStore";
 
 export function ProfileCompletionIndicator() {
   const percentage = useCompletionPercentage();
-  const incompleteFields = useIncompleteFields();
-  const { dismissItem, restoreItem } = useProfileCompletionStore();
+  const visibleFields = useVisibleProfileFields();
+  const { dismissItem } = useProfileCompletionStore();
   const [isExpanded, setIsExpanded] = useState(false);
   const isComplete = percentage === 100;
 
-  if (isComplete && incompleteFields.length === 0) {
+  if (isComplete) {
     return (
       <motion.div
         initial={{ opacity: 0, y: -10 }}
@@ -31,8 +31,8 @@ export function ProfileCompletionIndicator() {
         className="rounded-xl border border-moss/20 bg-moss/5 p-4 text-center"
       >
         <div className="flex items-center justify-center gap-2">
-          <CheckCircleIcon className="h-5 w-5 text-moss" />
-          <p className="font-semibold text-moss">🎉 Profile Complete!</p>
+          <SparklesIcon className="h-5 w-5 text-moss" />
+          <p className="font-semibold text-moss">🎉 Profile complete!</p>
         </div>
         <p className="mt-1 text-sm text-moss/70">
           Your profile is fully set up. Keep it updated to maintain
@@ -85,7 +85,7 @@ export function ProfileCompletionIndicator() {
 
       {/* Expanded Details */}
       <AnimatePresence>
-        {isExpanded && incompleteFields.length > 0 && (
+        {isExpanded && visibleFields.length > 0 && (
           <motion.div
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: "auto" }}
@@ -94,22 +94,30 @@ export function ProfileCompletionIndicator() {
             className="mt-4 space-y-2 border-t border-ink/10 dark:border-canvas/10 pt-4"
           >
             <p className="text-xs font-semibold uppercase tracking-wider text-ink/60 dark:text-canvas/60">
-              Complete these items to boost discoverability:
+              Complete missing items to boost discoverability:
             </p>
 
             <div className="space-y-2">
-              {incompleteFields.map((field) => (
+              {visibleFields.map((field) => (
                 <motion.div
                   key={field.id}
                   initial={{ opacity: 0, x: -10 }}
                   animate={{ opacity: 1, x: 0 }}
                   exit={{ opacity: 0, x: -10 }}
-                  className="group flex items-start justify-between gap-3 rounded-lg bg-canvas/50 dark:bg-ink/30 p-3 transition-colors hover:bg-canvas dark:hover:bg-ink/40"
+                  className={`group flex items-start justify-between gap-3 rounded-lg p-3 transition-colors ${
+                    field.filled
+                      ? "bg-moss/10 dark:bg-moss/15"
+                      : "bg-canvas/50 hover:bg-canvas dark:bg-ink/30 dark:hover:bg-ink/40"
+                  }`}
                 >
                   <div className="flex-1 min-w-0">
                     <Link href={field.link as any}>
-                      <p className="text-sm font-semibold text-sunrise hover:underline">
-                        {field.label}
+                      <p
+                        className={`text-sm font-semibold hover:underline ${
+                          field.filled ? "text-moss" : "text-sunrise"
+                        }`}
+                      >
+                        {field.filled ? `✓ ${field.label}` : field.label}
                       </p>
                     </Link>
                     <p className="text-xs text-ink/60 dark:text-canvas/60">
@@ -122,7 +130,11 @@ export function ProfileCompletionIndicator() {
                     className="mt-1 flex-shrink-0 rounded p-1 text-ink/40 hover:bg-ink/10 dark:text-canvas/40 dark:hover:bg-canvas/10 transition-colors"
                     whileHover={{ scale: 1.1 }}
                     whileTap={{ scale: 0.9 }}
-                    title="Dismiss"
+                    title={
+                      field.filled
+                        ? "Dismiss completed item"
+                        : "Dismiss reminder"
+                    }
                   >
                     <XMarkIcon className="h-4 w-4" />
                   </motion.button>
@@ -134,7 +146,7 @@ export function ProfileCompletionIndicator() {
       </AnimatePresence>
 
       {/* No incomplete fields message */}
-      {isExpanded && incompleteFields.length === 0 && !isComplete && (
+      {isExpanded && visibleFields.length === 0 && !isComplete && (
         <motion.div
           initial={{ opacity: 0, height: 0 }}
           animate={{ opacity: 1, height: "auto" }}

--- a/src/components/profile/ProfileForm.tsx
+++ b/src/components/profile/ProfileForm.tsx
@@ -17,6 +17,7 @@ const profileSchema = z.object({
       "Letters, numbers, underscores, and hyphens only.",
     ),
   bio: z.string().max(280, "Bio must be 280 characters or fewer.").optional(),
+  tags: z.string().max(160, "Tags must be 160 characters or fewer.").optional(),
   website: z.string().url("Enter a valid URL.").or(z.literal("")).optional(),
   twitter: z.string().max(50).optional(),
   github: z.string().max(50).optional(),
@@ -35,6 +36,7 @@ export function ProfileForm({ initialValues, onSave }: ProfileFormProps) {
     displayName: initialValues?.displayName ?? "",
     username: initialValues?.username ?? "",
     bio: initialValues?.bio ?? "",
+    tags: initialValues?.tags ?? "",
     website: initialValues?.website ?? "",
     twitter: initialValues?.twitter ?? "",
     github: initialValues?.github ?? "",
@@ -123,6 +125,16 @@ export function ProfileForm({ initialValues, onSave }: ProfileFormProps) {
           <span>{(values.bio ?? "").length}/280</span>
         </div>
       </div>
+
+      <Input
+        id="tags"
+        label="Tags"
+        type="text"
+        value={values.tags ?? ""}
+        onChange={set("tags")}
+        placeholder="nft-art, education, stellar"
+        error={errors.tags}
+      />
 
       <Input
         id="website"

--- a/src/hooks/useProfileCompletion.ts
+++ b/src/hooks/useProfileCompletion.ts
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { useCurrentUser } from "@/store/userStore";
 import { useProfileCompletionStore } from "@/store/profileCompletionStore";
+import { useCreatorProfileDetails } from "@/store/profileDetailsStore";
 
 /**
  * Hook to sync user profile data with completion tracker.
@@ -10,6 +11,7 @@ import { useProfileCompletionStore } from "@/store/profileCompletionStore";
  */
 export function useProfileCompletion() {
   const user = useCurrentUser();
+  const profile = useCreatorProfileDetails();
   const { setFields } = useProfileCompletionStore();
 
   useEffect(() => {
@@ -21,7 +23,7 @@ export function useProfileCompletion() {
         label: "Profile Avatar",
         description: "Add a profile picture to make your profile memorable",
         link: "/profile#avatar",
-        filled: !!user.avatarUrl,
+        filled: Boolean(profile.avatarUrl || user.avatarUrl),
         importance: "high",
       },
       {
@@ -29,7 +31,7 @@ export function useProfileCompletion() {
         label: "Display Name",
         description: "Set a professional display name for your profile",
         link: "/profile#displayName",
-        filled: !!user.displayName,
+        filled: Boolean(profile.displayName || user.displayName),
         importance: "high",
       },
       {
@@ -38,7 +40,7 @@ export function useProfileCompletion() {
         description:
           "Write a short bio to help supporters understand what you do",
         link: "/profile#bio",
-        filled: false, // Would need to fetch from profile data
+        filled: profile.bio.trim().length > 0,
         importance: "high",
       },
       {
@@ -47,7 +49,7 @@ export function useProfileCompletion() {
         description:
           "Add tags to improve discoverability and help supporters find you",
         link: "/profile#tags",
-        filled: false, // Would need to fetch from profile data
+        filled: profile.tags.length > 0,
         importance: "medium",
       },
       {
@@ -55,7 +57,7 @@ export function useProfileCompletion() {
         label: "Website or Portfolio",
         description: "Link to your personal website or portfolio",
         link: "/profile#website",
-        filled: false, // Would need to fetch from profile data
+        filled: profile.website.trim().length > 0,
         importance: "medium",
       },
       {
@@ -63,9 +65,9 @@ export function useProfileCompletion() {
         label: "Social Links",
         description: "Connect your social media profiles",
         link: "/profile#social",
-        filled: false, // Would need to fetch from profile data
+        filled: Boolean(profile.twitter.trim() || profile.github.trim()),
         importance: "low",
       },
     ]);
-  }, [user, setFields]);
+  }, [profile, user, setFields]);
 }

--- a/src/store/profileCompletionStore.ts
+++ b/src/store/profileCompletionStore.ts
@@ -22,9 +22,12 @@ interface ProfileCompletionState {
   fields: ProfileField[];
 
   setFields: (fields: ProfileField[]) => void;
+  resetFields: () => void;
   dismissItem: (itemId: string) => void;
   restoreItem: (itemId: string) => void;
+  clearDismissedItems: () => void;
   getCompletionPercentage: () => number;
+  getVisibleFields: () => ProfileField[];
   getIncompleteFields: () => ProfileField[];
   hasDismissedAll: () => boolean;
 }
@@ -88,6 +91,7 @@ export const useProfileCompletionStore = create<ProfileCompletionState>()(
       fields: defaultFields,
 
       setFields: (fields) => set({ fields }),
+      resetFields: () => set({ fields: defaultFields }),
 
       dismissItem: (itemId) =>
         set((state) => ({
@@ -101,16 +105,17 @@ export const useProfileCompletionStore = create<ProfileCompletionState>()(
           return { dismissedItems: updated };
         }),
 
+      clearDismissedItems: () => set({ dismissedItems: new Set<string>() }),
+
       getCompletionPercentage: () => {
         const state = get();
         const filledCount = state.fields.filter((f) => f.filled).length;
         return Math.round((filledCount / state.fields.length) * 100);
       },
 
-      getIncompleteFields: () => {
+      getVisibleFields: () => {
         const state = get();
         return state.fields
-          .filter((f) => !f.filled)
           .filter((f) => !state.dismissedItems.has(f.id))
           .sort((a, b) => {
             const importanceOrder = { high: 0, medium: 1, low: 2 };
@@ -118,6 +123,11 @@ export const useProfileCompletionStore = create<ProfileCompletionState>()(
               importanceOrder[a.importance] - importanceOrder[b.importance]
             );
           });
+      },
+
+      getIncompleteFields: () => {
+        const state = get();
+        return state.getVisibleFields().filter((f) => !f.filled);
       },
 
       hasDismissedAll: () => {
@@ -132,6 +142,13 @@ export const useProfileCompletionStore = create<ProfileCompletionState>()(
       partialize: (state) => ({
         dismissedItems: Array.from(state.dismissedItems),
       }),
+      merge: (persisted, current) => {
+        const stored = persisted as { dismissedItems?: string[] } | undefined;
+        return {
+          ...current,
+          dismissedItems: new Set(stored?.dismissedItems ?? []),
+        };
+      },
     },
   ),
 );
@@ -140,6 +157,9 @@ export const useProfileCompletionStore = create<ProfileCompletionState>()(
 
 export const useCompletionPercentage = () =>
   useProfileCompletionStore((s) => s.getCompletionPercentage());
+
+export const useVisibleProfileFields = () =>
+  useProfileCompletionStore((s) => s.getVisibleFields());
 
 export const useIncompleteFields = () =>
   useProfileCompletionStore((s) => s.getIncompleteFields());

--- a/src/store/profileDetailsStore.ts
+++ b/src/store/profileDetailsStore.ts
@@ -1,0 +1,55 @@
+/**
+ * Editable creator profile details used by profile settings and dashboard nudges.
+ *
+ * This local-first store mirrors fields that will be backed by the profile API.
+ */
+
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+export interface CreatorProfileDetails {
+  displayName: string;
+  username: string;
+  bio: string;
+  tags: string[];
+  website: string;
+  twitter: string;
+  github: string;
+  avatarUrl?: string;
+}
+
+interface ProfileDetailsState {
+  profile: CreatorProfileDetails;
+  updateProfile: (patch: Partial<CreatorProfileDetails>) => void;
+  setAvatarUrl: (avatarUrl?: string) => void;
+}
+
+const emptyProfile: CreatorProfileDetails = {
+  displayName: "",
+  username: "",
+  bio: "",
+  tags: [],
+  website: "",
+  twitter: "",
+  github: "",
+  avatarUrl: undefined,
+};
+
+export const useProfileDetailsStore = create<ProfileDetailsState>()(
+  persist(
+    (set) => ({
+      profile: emptyProfile,
+      updateProfile: (patch) =>
+        set((state) => ({ profile: { ...state.profile, ...patch } })),
+      setAvatarUrl: (avatarUrl) =>
+        set((state) => ({ profile: { ...state.profile, avatarUrl } })),
+    }),
+    {
+      name: "creator-profile-details-storage",
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);
+
+export const useCreatorProfileDetails = () =>
+  useProfileDetailsStore((state) => state.profile);


### PR DESCRIPTION
Closes #481 

### Motivation
- Creators often leave profiles missing avatar, bio, tags, and social links which reduces discoverability, so the dashboard should surface what’s missing and why it matters.
- Provide a clear, action-oriented nudge with percentage, progress bar, direct links, dismissible items, and a celebration state at 100% to increase completion rates.

### Description
- Add a persistent local store `useProfileDetailsStore` to mirror editable profile fields (avatar, displayName, bio, tags, website, twitter, github) so the dashboard can compute completion from saved values.
- Update `useProfileCompletion` to compute field `filled` states from the persisted profile details and current user session instead of hardcoded placeholders.
- Replace the dashboard widget with an enhanced `ProfileCompletionIndicator` that shows percentage, an animated `ProgressBar`, an expandable list of visible fields with direct `Link` actions, dismiss controls, completed-item styling, and a 100% celebration state.
- Wire profile settings: add `tags` field to `ProfileForm` and update `app/profile/page.tsx` to persist form saves and avatar uploads into the profile details store; enhance `profileCompletionStore` with helpers (`resetFields`, `clearDismissedItems`, `getVisibleFields`) and persistence merge logic for `Set` hydration.