### PR TITLE
fix(test): exclude Playwright e2e test suite from vitest runner

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig, configDefaults } from 'vitest/config'
 import { resolve } from 'path'
 
 export default defineConfig({
@@ -6,6 +6,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
+    exclude: ['tests/e2e/**', ...configDefaults.exclude],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

Fixes #603.

Previously, \`vitest.config.ts\` used Vitest's default include pattern without excluding the Playwright end-to-end test suite in \`tests/e2e/**\`. As a result, running \`npm test\` (\`vitest run\`) picked up Playwright spec files (\`*.spec.ts\`), causing 8 false-positive file failures.

### Changes
- Imported \`configDefaults\` from \`vitest/config\`.
- Added \`exclude: ['tests/e2e/**', ...configDefaults.exclude]\` under \`test\` config in \`vitest.config.ts\`.

### Verification
- Excludes Playwright e2e test suite while maintaining standard default Vitest exclusions.
