### PR TITLE
fix(schema): wire Category enum validation into creatorSchema

### DIFF
--- a/src/schemas/__tests__/creatorSchema.test.ts
+++ b/src/schemas/__tests__/creatorSchema.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { creatorSchema, creatorUsernameSchema, categorySchema } from "../creatorSchema";
+
+describe("creatorSchema & categorySchema (#595)", () => {
+  it("validates valid usernames", () => {
+    expect(creatorUsernameSchema.safeParse("alice").success).toBe(true);
+    expect(creatorUsernameSchema.safeParse("bob_123").success).toBe(true);
+    expect(creatorUsernameSchema.safeParse("creator-name").success).toBe(true);
+  });
+
+  it("rejects invalid usernames", () => {
+    expect(creatorUsernameSchema.safeParse("a").success).toBe(false);
+    expect(creatorUsernameSchema.safeParse("_invalid").success).toBe(false);
+    expect(creatorUsernameSchema.safeParse("invalid space").success).toBe(false);
+  });
+
+  it("validates supported categories in creatorSchema", () => {
+    const valid = {
+      username: "stellar_artist",
+      categories: ["art", "crypto", "defi"],
+      tags: ["stellar", "nft-art"],
+    };
+
+    const parsed = creatorSchema.safeParse(valid);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.categories).toEqual(["art", "crypto", "defi"]);
+    }
+  });
+
+  it("rejects unsupported categories in creatorSchema", () => {
+    const invalid = {
+      username: "stellar_artist",
+      categories: ["unsupported_category"],
+    };
+
+    const parsed = creatorSchema.safeParse(invalid);
+    expect(parsed.success).toBe(false);
+  });
+
+  it("defaults categories to empty array when omitted", () => {
+    const parsed = creatorSchema.safeParse({ username: "john_doe" });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.categories).toEqual([]);
+      expect(parsed.data.tags).toEqual([]);
+    }
+  });
+});

--- a/src/schemas/creatorSchema.ts
+++ b/src/schemas/creatorSchema.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
-import type { Category } from "@/utils/categories";
+import { CATEGORIES } from "@/utils/categories";
+
+export const categorySchema = z.enum(CATEGORIES);
 
 export const creatorUsernameSchema = z
   .string()
@@ -13,9 +15,10 @@ export const creatorUsernameSchema = z
 
 export const creatorSchema = z.object({
   username: creatorUsernameSchema,
-  categories: z.array(z.string()).optional().default([]),
+  categories: z.array(categorySchema).optional().default([]),
   tags: z.array(z.string()).max(10).optional().default([]),
 });
 
 export type CreatorSchemaValues = z.infer<typeof creatorSchema>;
 export type CreatorWithCategoriesTags = z.infer<typeof creatorSchema>;
+


### PR DESCRIPTION
## Summary

Fixes #595.

Previously, \`src/schemas/creatorSchema.ts\` had an unused \`Category\` type import while leaving \`categories\` typed as a generic \`z.array(z.string())\`, allowing invalid/unsupported category values to pass schema parsing.

### Changes
- Imported \`CATEGORIES\` from \`@/utils/categories\`.
- Exported \`categorySchema = z.enum(CATEGORIES)\`.
- Updated \`creatorSchema\` to use \`z.array(categorySchema).optional().default([])\`.
- Added unit tests in \`src/schemas/__tests__/creatorSchema.test.ts\` verifying category validation, rejection of unsupported categories, and defaults (5/5 passing).

### Verification
- Tested with Bun Test: \`5 passed, 0 failed\`.
