### PR TITLE
fix(api): wire DEFAULT_RETRIES into RequestOptions and requestQueue

### DIFF
--- a/src/services/__tests__/api-retries.test.ts
+++ b/src/services/__tests__/api-retries.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { DEFAULT_RETRIES, getApiRateLimitStatus } from "../api";
+
+describe("API Service Retries (#594)", () => {
+  it("exports a defined DEFAULT_RETRIES constant equal to 3", () => {
+    expect(DEFAULT_RETRIES).toBe(3);
+    expect(typeof DEFAULT_RETRIES).toBe("number");
+  });
+
+  it("provides active rate limit and queue status", () => {
+    const status = getApiRateLimitStatus();
+    expect(status).toHaveProperty("isLimited");
+    expect(status).toHaveProperty("retryAfterMs");
+    expect(status).toHaveProperty("remainingRequests");
+    expect(status).toHaveProperty("queuedRequests");
+    expect(status).toHaveProperty("limit");
+    expect(status).toHaveProperty("windowMs");
+  });
+});

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,7 +2,7 @@ import { RequestQueue } from "@/utils/requestQueue";
 import { RateLimiter } from "@/utils/rateLimiter";
 import type { TagWithCount } from "@/utils/categories";
 import { API_BASE_URL } from "@/config/env";
-const DEFAULT_RETRIES = 3;
+export const DEFAULT_RETRIES = 3;
 
 export interface CreatorProfile {
   username: string;
@@ -50,6 +50,7 @@ interface RequestOptions {
    */
   critical?: boolean;
   throttleMs?: number;
+  retries?: number;
 }
 
 const sleep = (delayMs: number) => new Promise<void>((resolve) => setTimeout(resolve, delayMs));
@@ -186,7 +187,7 @@ async function request<T>(path: string, init?: RequestInit, options?: RequestOpt
 
         return executeFetch<T>(path, init, throttleMs);
       },
-      { maxRetries: 4, baseDelayMs: 250 },
+      { maxRetries: options?.retries ?? DEFAULT_RETRIES, baseDelayMs: 250 },
     );
 
     notifyStatusChange();


### PR DESCRIPTION
## Summary

Fixes #594.

Previously, \`const DEFAULT_RETRIES = 3\` in \`src/services/api.ts\` was unused, while \`requestQueue.enqueue\` used a hardcoded literal without allowing request-level retry overrides.

### Changes
- Exported \`DEFAULT_RETRIES = 3\` so retry configurations are transparent and testable.
- Added \`retries?: number\` to \`RequestOptions\`.
- Wired \`maxRetries: options?.retries ?? DEFAULT_RETRIES\` into \`requestQueue.enqueue\`.
- Added unit tests in \`src/services/__tests__/api-retries.test.ts\` verifying export stability and rate limit status properties (2/2 passing).

### Verification
- Tested with Bun Test: \`2 passed, 0 failed\`.
