### PR TITLE
fix(utils): wire StellarNetwork type into helper functions and re-export

### DIFF
--- a/src/utils/__tests__/stellar.test.ts
+++ b/src/utils/__tests__/stellar.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatAddress,
+  getNetworkPassphrase,
+  STELLAR_NETWORK,
+  type StellarNetwork,
+} from "../stellar";
+
+describe("Stellar Utilities & Network Types (#588)", () => {
+  it("formats Stellar public key addresses with truncation", () => {
+    expect(formatAddress("GBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")).toBe("GBXX...XXXX");
+    expect(formatAddress("")).toBe("");
+  });
+
+  it("retrieves the network passphrase for default and explicit networks", () => {
+    const defaultPassphrase = getNetworkPassphrase();
+    expect(typeof defaultPassphrase).toBe("string");
+    expect(defaultPassphrase.length).toBeGreaterThan(0);
+
+    const testnetPassphrase = getNetworkPassphrase("TESTNET");
+    expect(testnetPassphrase).toBe("Test SDF Network ; September 2015");
+
+    const publicPassphrase = getNetworkPassphrase("PUBLIC");
+    expect(publicPassphrase).toBe("Public Global Stellar Network ; September 2015");
+  });
+
+  it("exports STELLAR_NETWORK matching StellarNetwork type", () => {
+    const network: StellarNetwork = STELLAR_NETWORK;
+    expect(["TESTNET", "PUBLIC"]).toContain(network);
+  });
+});

--- a/src/utils/stellar.ts
+++ b/src/utils/stellar.ts
@@ -6,22 +6,31 @@ import {
   NETWORKS,
 } from "@/lib/wallet";
 
-export const STELLAR_NETWORK = DEFAULT_NETWORK;
-export const STELLAR_HORIZON_URL = NETWORKS[STELLAR_NETWORK].horizonUrl;
+export type { StellarNetwork };
+
+export const STELLAR_NETWORK: StellarNetwork = DEFAULT_NETWORK;
+export const STELLAR_HORIZON_URL: string = NETWORKS[STELLAR_NETWORK].horizonUrl;
 
 export const stellarServer = new Horizon.Server(STELLAR_HORIZON_URL);
 
-export const getNetworkPassphrase = () =>
-  NETWORKS[STELLAR_NETWORK].passphrase;
+export const getNetworkPassphrase = (network: StellarNetwork = STELLAR_NETWORK) =>
+  NETWORKS[network].passphrase;
 
 export const formatAddress = (address: string) => {
   if (!address) return "";
   return `${address.slice(0, 4)}...${address.slice(-4)}`;
 };
 
-export const getBalance = async (publicKey: string) => {
+export const getBalance = async (
+  publicKey: string,
+  network: StellarNetwork = STELLAR_NETWORK,
+) => {
   try {
-    const account = await stellarServer.loadAccount(publicKey);
+    const server =
+      network === STELLAR_NETWORK
+        ? stellarServer
+        : new Horizon.Server(NETWORKS[network].horizonUrl);
+    const account = await server.loadAccount(publicKey);
     const balance = account.balances.find((b) => b.asset_type === "native");
     return balance ? balance.balance : "0.0";
   } catch (error) {
@@ -29,3 +38,4 @@ export const getBalance = async (publicKey: string) => {
     return "0.0";
   }
 };
+


### PR DESCRIPTION
## Summary

Fixes #588.

Previously, \`src/utils/stellar.ts\` imported \`type StellarNetwork\` from \`@/lib/wallet\` without using or re-exporting it, leaving helper functions implicitly tied to global defaults rather than typed network signatures.

### Changes
- Re-exported \`type { StellarNetwork }\` from \`src/utils/stellar.ts\`.
- Explicitly typed \`export const STELLAR_NETWORK: StellarNetwork = DEFAULT_NETWORK\`.
- Added optional typed parameter \`network: StellarNetwork = STELLAR_NETWORK\` to \`getNetworkPassphrase\` and \`getBalance\`.
- Added unit tests in \`src/utils/__tests__/stellar.test.ts\` verifying address formatting, network passphrase resolution across networks, and type compliance (3/3 passing).

### Verification
- Tested with Bun Test: \`3 passed, 0 failed\`.
