### PR TITLE
fix(utils): route errorLogger environment checks through validated env config

### DIFF
--- a/src/utils/__tests__/errorLogger.test.ts
+++ b/src/utils/__tests__/errorLogger.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { logError } from "../errorLogger";
+
+describe("errorLogger utility (#586)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs structured error without crashing", () => {
+    const spyError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const err = new Error("Something went wrong");
+
+    expect(() => logError(err, { digest: "test-digest-123" })).not.toThrow();
+    expect(spyError).toHaveBeenCalled();
+  });
+});

--- a/src/utils/errorLogger.ts
+++ b/src/utils/errorLogger.ts
@@ -1,3 +1,5 @@
+import { IS_DEV } from "@/config/env";
+
 /**
  * Centralized error logging utility.
  * In dev: logs to console with full details.
@@ -10,7 +12,7 @@ export interface ErrorInfo {
 }
 
 export function logError(error: Error, info?: ErrorInfo): void {
-  if (process.env.NODE_ENV === "development") {
+  if (IS_DEV) {
     console.group("[ErrorBoundary]");
     console.error("Error:", error);
     if (info?.componentStack) {


### PR DESCRIPTION
## Summary

Fixes #586.

Previously, \`src/utils/errorLogger.ts\` directly accessed \`process.env.NODE_ENV\`, bypassing the centralized, fail-fast validated application configuration in \`@/config/env\`.

### Changes
- Imported \`IS_DEV\` from \`@/config/env\`.
- Replaced direct \`process.env.NODE_ENV === "development"\` read with \`IS_DEV\`.
- Added unit test in \`src/utils/__tests__/errorLogger.test.ts\` verifying structured error logging.

### Verification
- Tested with Bun Test: \`1 passed, 0 failed\`.
