### PR TITLE
fix(utils): route performanceUtils debug logs through validated env config

### DIFF
--- a/src/utils/__tests__/performanceUtils.test.ts
+++ b/src/utils/__tests__/performanceUtils.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import {
+  getMetricRating,
+  formatMetricValue,
+  measureAsync,
+} from "../performanceUtils";
+
+describe("performanceUtils utility (#587)", () => {
+  it("computes correct metric ratings against budgets", () => {
+    expect(getMetricRating("LCP", 2000)).toBe("good");
+    expect(getMetricRating("LCP", 3500)).toBe("needs-improvement");
+    expect(getMetricRating("LCP", 5000)).toBe("poor");
+  });
+
+  it("formats metric values correctly for time and layout shift", () => {
+    expect(formatMetricValue("CLS", 0.0512)).toBe("0.051");
+    expect(formatMetricValue("FCP", 1450.6)).toBe("1451ms");
+  });
+
+  it("measures async execution without throwing", async () => {
+    const result = await measureAsync("test-task", async () => {
+      return 42;
+    });
+    expect(result).toBe(42);
+  });
+});

--- a/src/utils/performanceUtils.ts
+++ b/src/utils/performanceUtils.ts
@@ -1,4 +1,5 @@
 import { PERFORMANCE_BUDGETS, type MetricName } from "@/lib/webVitals";
+import { IS_DEV } from "@/config/env";
 
 export type MetricRating = "good" | "needs-improvement" | "poor";
 
@@ -33,7 +34,7 @@ export async function measureAsync<T>(
     return await fn();
   } finally {
     const duration = performance.now() - start;
-    if (process.env.NODE_ENV === "development") {
+    if (IS_DEV) {
       console.debug(`[Perf] ${name}: ${duration.toFixed(2)}ms`);
     }
     // Mark for DevTools Performance panel


### PR DESCRIPTION
## Summary

Fixes #587.

Previously, \`src/utils/performanceUtils.ts\` directly read \`process.env.NODE_ENV\`, bypassing the centralized, validated config system in \`@/config/env\`.

### Changes
- Imported \`IS_DEV\` from \`@/config/env\`.
- Replaced direct \`process.env.NODE_ENV === "development"\` read in \`measureAsync\` with \`IS_DEV\`.
- Added unit tests in \`src/utils/__tests__/performanceUtils.test.ts\` verifying metric rating, metric formatting, and async measurement (3/3 passing).

### Verification
- Tested with Bun Test: \`3 passed, 0 failed\`.
