### PR TITLE
docs(config): align supported locales comment with routing config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,7 +9,7 @@ const withBundleAnalyzer = createBundleAnalyzer({
 });
 
 // i18n is handled via next-intl with locale routing
-// Supported locales: en, es, fr, zh, ar, he — preference persisted in localStorage
+// Supported locales: en, es, fr, zh, ar — preference persisted in localStorage
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   typedRoutes: true,


### PR DESCRIPTION
## Summary

Fixes #590.

Previously, a comment in \`next.config.ts\` claimed 6 supported locales including Hebrew (\`he\`), whereas the actual \`next-intl\` configuration in \`src/i18n/routing.ts\` and the \`messages/\` directory implement 5 locales (\`en\`, \`es\`, \`fr\`, \`zh\`, \`ar\`).

### Changes
- Updated the \`next.config.ts\` comment to reflect the exact 5 active locales (\`en\`, \`es\`, \`fr\`, \`zh\`, \`ar\`), preventing stale documentation traps.

### Verification
- Verified alignment between \`next.config.ts\`, \`src/i18n/routing.ts\`, and \`messages/\` translation files.
