### PR TITLE
fix(middleware): use shared routing configuration and comprehensive pathname matcher

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { config } from "../middleware";
+import { routing } from "../i18n/routing";
+
+describe("Middleware Routing Configuration (#576)", () => {
+  it("imports and shares centralized routing options", () => {
+    expect(routing.locales).toEqual(["en", "es", "fr", "zh", "ar"]);
+    expect(routing.defaultLocale).toBe("en");
+    expect(routing.localePrefix).toBe("as-needed");
+  });
+
+  it("configures comprehensive route matcher excluding api and static files", () => {
+    expect(config.matcher).toBeDefined();
+    expect(Array.isArray(config.matcher)).toBe(true);
+    expect(config.matcher[0]).toBe("/((?!api|_next|_vercel|.*\\..*).*)");
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,13 @@
-import createMiddleware from 'next-intl/middleware';
+import createMiddleware from "next-intl/middleware";
+import { routing } from "./i18n/routing";
 
-export default createMiddleware({
-  locales: ['en', 'es', 'fr', 'zh', 'ar'],
-  defaultLocale: 'en',
-  localePrefix: 'as-needed'
-});
+export default createMiddleware(routing);
 
 export const config = {
-  matcher: ['/', '/(en|es|fr|zh|ar)/:path*']
+  // Match all request paths except for:
+  // - API routes (/api/*)
+  // - Next.js internals (/_next/*, /_vercel/*)
+  // - Static files containing a dot (e.g. favicon.ico, images)
+  matcher: ["/((?!api|_next|_vercel|.*\\..*).*)"],
 };
+


### PR DESCRIPTION
## Summary

Fixes #576.

Previously, \`src/middleware.ts\` redefined routing options inline rather than importing from \`src/i18n/routing.ts\`, and used a restrictive \`matcher: ['/', '/(en|es|fr|zh|ar)/:path*']\` that risked missing deep unprefixed dynamic routes and explicitly lacked unified exclude patterns.

### Changes
- Imported shared \`routing\` from \`src/i18n/routing.ts\` in \`src/middleware.ts\` (\`createMiddleware(routing)\`).
- Updated route matcher to \`['/((?!api|_next|_vercel|.*\\..*).*)']\` to intercept all page routes across default and prefixed locales while excluding \`/api/*\`, \`/_next/*\`, \`/_vercel/*\`, and static files.
- Added unit tests in \`src/__tests__/middleware.test.ts\` verifying shared configuration and matcher pattern (2/2 passing).

### Verification
- Tested with Bun Test: \`2 passed, 0 failed\`.
