### PR TITLE
fix(layout): add dynamic dir attribute to html element based on locale RTL support

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -2,6 +2,7 @@ import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 import { routing } from '@/i18n/routing';
+import { isRTL, type Locale } from '@/i18n/config';
 
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { InstallPrompt } from "@/components/InstallPrompt";
@@ -37,9 +38,10 @@ export default async function LocaleLayout({
   // Providing all messages to the client
   // side is the easiest way to get started
   const messages = await getMessages();
+  const dir = isRTL(locale as Locale) ? 'rtl' : 'ltr';
 
   return (
-    <html lang={locale} suppressHydrationWarning>
+    <html lang={locale} dir={dir} suppressHydrationWarning>
       <head>
         <script
           dangerouslySetInnerHTML={{

--- a/src/i18n/__tests__/config.test.ts
+++ b/src/i18n/__tests__/config.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { isRTL, locales, defaultLocale, localeNames } from "../config";
+
+describe("i18n Config & RTL Resolution (#575)", () => {
+  it("identifies Arabic (ar) as RTL", () => {
+    expect(isRTL("ar")).toBe(true);
+  });
+
+  it("identifies non-Arabic locales as LTR", () => {
+    expect(isRTL("en")).toBe(false);
+    expect(isRTL("es")).toBe(false);
+    expect(isRTL("fr")).toBe(false);
+    expect(isRTL("zh")).toBe(false);
+  });
+
+  it("has valid defaultLocale and localeNames", () => {
+    expect(defaultLocale).toBe("en");
+    expect(locales).toContain("en");
+    expect(locales).toContain("ar");
+    expect(localeNames.ar).toBe("العربية");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #575.

Previously, \`src/app/[locale]/layout.tsx\` rendered \`<html lang={locale} suppressHydrationWarning>\` without setting the \`dir\` attribute, causing RTL languages like Arabic (\`ar\`) to default to \`ltr\` layout.

### Changes
- Imported \`isRTL\` and \`type Locale\` from \`@/i18n/config\`.
- Computed \`const dir = isRTL(locale as Locale) ? 'rtl' : 'ltr'\` in \`LocaleLayout\`.
- Passed \`dir={dir}\` to the root \`<html>\` element.
- Added unit tests in \`src/i18n/__tests__/config.test.ts\` asserting RTL identification for Arabic and LTR for non-RTL locales (3/3 passing).

### Verification
- Tested with Bun Test: \`3 passed, 0 failed\`.
