### PR TITLE
fix(schemas): export and wire EMAIL_PATTERN into team email schemas and fix test assertion

### DIFF
--- a/src/schemas/__tests__/teamSchema.test.ts
+++ b/src/schemas/__tests__/teamSchema.test.ts
@@ -9,6 +9,8 @@ import {
   inviteMemberSchema,
   revenueSplitValidationSchema,
   teamNameCheckSchema,
+  EMAIL_PATTERN,
+  emailSchema,
 } from "@/schemas/teamSchema";
 import { z } from "zod";
 
@@ -43,7 +45,7 @@ describe("Team Schema Validations", () => {
         split: 50,
         isActive: true,
       };
-      expect(teamMemberSchema.parse(member)).toEqual(member);
+      expect(teamMemberSchema.parse(member)).toMatchObject(member);
     });
 
     it("makes email optional", () => {
@@ -308,4 +310,19 @@ describe("Team Schema Validations", () => {
       ).toThrow();
     });
   });
+
+  describe("EMAIL_PATTERN & emailSchema (#574)", () => {
+    it("validates well-formed emails", () => {
+      expect(EMAIL_PATTERN.test("user@example.com")).toBe(true);
+      expect(emailSchema.parse("team.lead@stellar.org")).toBe("team.lead@stellar.org");
+    });
+
+    it("rejects malformed email addresses", () => {
+      expect(EMAIL_PATTERN.test("plainaddress")).toBe(false);
+      expect(EMAIL_PATTERN.test("@missingusername.com")).toBe(false);
+      expect(EMAIL_PATTERN.test("user@domain")).toBe(false);
+      expect(() => emailSchema.parse("invalid-email")).toThrow();
+    });
+  });
 });
+

--- a/src/schemas/teamSchema.ts
+++ b/src/schemas/teamSchema.ts
@@ -1,8 +1,14 @@
 import { z } from "zod";
 
 // Basic validation patterns
-const TEAM_NAME_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{1,31}$/;
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+export const TEAM_NAME_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{1,31}$/;
+export const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Email schema helper
+export const emailSchema = z
+  .string()
+  .email("Invalid email address")
+  .regex(EMAIL_PATTERN, "Invalid email address");
 
 // Team name schema
 export const teamNameSchema = z
@@ -21,7 +27,7 @@ export const teamMemberSchema = z.object({
     .string()
     .min(1, "Member name is required")
     .max(100, "Member name is too long"),
-  email: z.string().email("Invalid email address").optional().or(z.literal("")),
+  email: emailSchema.optional().or(z.literal("")),
   role: z.enum(["owner", "admin", "member", "viewer"]).optional().default("member"),
   split: z
     .number()
@@ -37,7 +43,7 @@ export type TeamMemberInput = z.infer<typeof teamMemberSchema>;
 // Team invitation schema
 export const teamInvitationSchema = z.object({
   id: z.string().default(() => crypto.randomUUID()),
-  email: z.string().email("Invalid email address"),
+  email: emailSchema,
   sentAt: z.string().datetime().default(() => new Date().toISOString()),
   status: z
     .enum(["pending", "accepted", "rejected"])
@@ -88,7 +94,7 @@ export type CreateTeamRequest = z.infer<typeof createTeamSchema>;
 // Add member request schema
 export const addMemberSchema = z.object({
   name: z.string().min(1).max(100),
-  email: z.string().email().optional(),
+  email: emailSchema.optional(),
   split: z.number().min(0).max(100).int(),
 });
 
@@ -104,7 +110,7 @@ export type UpdateSplitRequest = z.infer<typeof updateSplitSchema>;
 
 // Invite member schema
 export const inviteMemberSchema = z.object({
-  email: z.string().email("Invalid email address"),
+  email: emailSchema,
   message: z.string().max(500).optional(),
 });
 


### PR DESCRIPTION
## Summary

Fixes #574.

Previously, \`EMAIL_PATTERN\` in \`src/schemas/teamSchema.ts\` was unused, leaving email inputs without regex format enforcement, and \`src/schemas/__tests__/teamSchema.test.ts\` had a test failure due to \`toEqual(member)\` asserting against generated default schema fields.

### Changes
- Exported \`EMAIL_PATTERN\` and \`TEAM_NAME_PATTERN\`.
- Created centralized \`emailSchema\` combining \`z.string().email()\` and \`.regex(EMAIL_PATTERN)\`.
- Wired \`emailSchema\` across \`teamMemberSchema\`, \`teamInvitationSchema\`, \`addMemberSchema\`, and \`inviteMemberSchema\`.
- Fixed test assertion in \`src/schemas/__tests__/teamSchema.test.ts\` using \`toMatchObject\` and added test suite for \`EMAIL_PATTERN\` and \`emailSchema\`.

### Verification
- Tested with Bun Test: \`33 passed, 0 failed\`.
