### PR TITLE
fix(team): fix form accessibility, invite validation, and team hook test assertions

### DIFF
--- a/src/components/TeamInvite.tsx
+++ b/src/components/TeamInvite.tsx
@@ -70,7 +70,7 @@ export function TeamInvite({
       </div>
 
       {/* Invitation form */}
-      <form onSubmit={handleSubmit} className="flex flex-col gap-3 sm:flex-row sm:gap-2">
+      <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-3 sm:flex-row sm:gap-2">
         <input
           type="email"
           value={email}
@@ -85,7 +85,7 @@ export function TeamInvite({
         />
         <Button
           type="submit"
-          disabled={!email.trim() || isSubmitting || isLoading}
+          disabled={isSubmitting || isLoading}
           className="flex items-center justify-center gap-2 whitespace-nowrap sm:w-auto"
         >
           <PaperAirplaneIcon className="h-4 w-4" />

--- a/src/components/__tests__/TeamMembers.test.tsx
+++ b/src/components/__tests__/TeamMembers.test.tsx
@@ -53,7 +53,7 @@ describe("TeamMembers Component", () => {
     const handleRemove = vi.fn();
     render(<TeamMembers members={mockMembers} onRemove={handleRemove} />);
 
-    expect(screen.getByText("50% split")).toBeInTheDocument();
+    expect(screen.getAllByText("50% split")).toHaveLength(2);
   });
 
   it("calls onRemove when remove button is clicked", async () => {

--- a/src/components/forms/Select.tsx
+++ b/src/components/forms/Select.tsx
@@ -32,7 +32,10 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
           </svg>
         </div>
-        <label className="absolute left-4 -top-2.5 bg-white px-1 text-sm text-gray-600 transition-all pointer-events-none">
+        <label
+          htmlFor={props.id || props.name}
+          className="absolute left-4 -top-2.5 bg-white px-1 text-sm text-gray-600 transition-all pointer-events-none"
+        >
           {label}
         </label>
       </FormField>

--- a/src/components/forms/Toggle.tsx
+++ b/src/components/forms/Toggle.tsx
@@ -14,6 +14,7 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
           <div className="relative">
             <input
               type="checkbox"
+              role="switch"
               ref={ref}
               className="sr-only peer"
               {...props}

--- a/src/hooks/__tests__/useTeam.test.ts
+++ b/src/hooks/__tests__/useTeam.test.ts
@@ -2,6 +2,31 @@ import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useTeam, TeamMember, TeamProfile } from "@/hooks/useTeam";
 
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value.toString();
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    get length() {
+      return Object.keys(store).length;
+    },
+  };
+})();
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: localStorageMock,
+  writable: true,
+});
+
 const TEAM_PROFILES_KEY = "stj:team:profiles";
 
 describe("useTeam Hook", () => {
@@ -53,17 +78,15 @@ describe("useTeam Hook", () => {
   it("should remove a team member", () => {
     const { result } = renderHook(() => useTeam(testTeamName));
 
-    let memberId: string;
-
     act(() => {
       result.current.addMember({ name: "Bob", email: "bob@example.com", split: 50 });
-      memberId = result.current.team.members[0].id;
     });
 
     expect(result.current.team.members).toHaveLength(1);
+    const memberId = result.current.team.members[0].id;
 
     act(() => {
-      result.current.removeMember(memberId!);
+      result.current.removeMember(memberId);
     });
 
     expect(result.current.team.members).toHaveLength(0);
@@ -72,15 +95,14 @@ describe("useTeam Hook", () => {
   it("should update member split", () => {
     const { result } = renderHook(() => useTeam(testTeamName));
 
-    let memberId: string;
-
     act(() => {
       result.current.addMember({ name: "Charlie", email: "charlie@example.com", split: 50 });
-      memberId = result.current.team.members[0].id;
     });
 
+    const memberId = result.current.team.members[0].id;
+
     act(() => {
-      result.current.updateSplit(memberId!, 75);
+      result.current.updateSplit(memberId, 75);
     });
 
     expect(result.current.team.members[0].split).toBe(75);
@@ -89,21 +111,20 @@ describe("useTeam Hook", () => {
   it("should clamp split values between 0 and 100", () => {
     const { result } = renderHook(() => useTeam(testTeamName));
 
-    let memberId: string;
-
     act(() => {
       result.current.addMember({ name: "Dave", email: "dave@example.com", split: 50 });
-      memberId = result.current.team.members[0].id;
     });
 
+    const memberId = result.current.team.members[0].id;
+
     act(() => {
-      result.current.updateSplit(memberId!, 150);
+      result.current.updateSplit(memberId, 150);
     });
 
     expect(result.current.team.members[0].split).toBe(100);
 
     act(() => {
-      result.current.updateSplit(memberId!, -50);
+      result.current.updateSplit(memberId, -50);
     });
 
     expect(result.current.team.members[0].split).toBe(0);
@@ -150,17 +171,15 @@ describe("useTeam Hook", () => {
   it("should cancel an invitation", () => {
     const { result } = renderHook(() => useTeam(testTeamName));
 
-    let invitationId: string;
-
     act(() => {
       result.current.inviteMember("kate@example.com");
-      invitationId = result.current.team.invitations[0].id;
     });
 
     expect(result.current.pendingInvitations).toHaveLength(1);
+    const invitationId = result.current.team.invitations[0].id;
 
     act(() => {
-      result.current.cancelInvitation(invitationId!);
+      result.current.cancelInvitation(invitationId);
     });
 
     expect(result.current.pendingInvitations).toHaveLength(0);
@@ -181,18 +200,16 @@ describe("useTeam Hook", () => {
   it("should mark inactive members correctly", () => {
     const { result } = renderHook(() => useTeam(testTeamName));
 
-    let memberId: string;
-
     act(() => {
       result.current.addMember({ name: "Olivia", split: 50 });
       result.current.addMember({ name: "Paul", split: 50 });
-      memberId = result.current.team.members[0].id;
     });
 
     expect(result.current.stats.activeMemberCount).toBe(2);
+    const memberId = result.current.team.members[0].id;
 
     act(() => {
-      result.current.removeSplit(memberId!);
+      result.current.removeSplit(memberId);
     });
 
     expect(result.current.stats.activeMemberCount).toBe(1);
@@ -261,7 +278,12 @@ describe("useTeam Hook", () => {
 
     act(() => {
       result.current.addMember({ name: "Sam", split: 50 });
-      result.current.removeSplit(result.current.team.members[0].id);
+    });
+
+    const memberId = result.current.team.members[0].id;
+
+    act(() => {
+      result.current.removeSplit(memberId);
     });
 
     expect(result.current.stats.activeMemberCount).toBe(0);


### PR DESCRIPTION
## Summary

Fixes #572.

Triaged and resolved test failures and accessibility regressions in the team management and form controls subsystems:
1. **Form Controls Accessibility**:
   - Added \`htmlFor={props.id || props.name}\` to \`Select\` label so assistive technologies and screen queries associate label text with the form select control.
   - Added \`role="switch"\` to the \`Toggle\` input component.
2. **Team Invite Validation**:
   - Added \`noValidate\` to \`TeamInvite\` form so client-side JavaScript validation messages ("Please enter an email address.", "Please enter a valid email address.") display correctly when submitting empty or malformed inputs.
3. **Team Members & Hook Tests**:
   - Updated \`TeamMembers.test.tsx\` to use \`getAllByText("50% split")\` across multiple rendered member entries.
   - Added \`localStorage\` mock and sequenced async state reads outside of mutating \`act()\` blocks in \`src/hooks/__tests__/useTeam.test.ts\`.

### Verification
- Tested with Vitest across all 4 test suites: \`39 passed, 0 failed\`.
