### PR TITLE
test(button): align variant assertions with design system tokens and add outline/danger tests

### DIFF
--- a/src/components/__tests__/Button.test.tsx
+++ b/src/components/__tests__/Button.test.tsx
@@ -10,21 +10,43 @@ describe('Button Component', () => {
     const button = screen.getByRole('button', { name: 'Click me' })
     
     expect(button).toBeInTheDocument()
-    expect(button).toHaveClass('bg-sunrise', 'text-white')
+    expect(button).toHaveClass('bg-purple-600', 'text-white')
   })
 
   it('renders with secondary variant', () => {
     render(<Button variant="secondary">Secondary</Button>)
     const button = screen.getByRole('button', { name: 'Secondary' })
     
-    expect(button).toHaveClass('bg-wave', 'text-white')
+    expect(button).toHaveClass('bg-gray-200', 'text-gray-900')
   })
 
   it('renders with ghost variant', () => {
     render(<Button variant="ghost">Ghost</Button>)
     const button = screen.getByRole('button', { name: 'Ghost' })
     
-    expect(button).toHaveClass('bg-transparent', 'border', 'border-ink/20')
+    expect(button).toHaveClass('hover:bg-gray-100', 'text-gray-700')
+  })
+
+  it('renders with outline variant', () => {
+    render(<Button variant="outline">Outline</Button>)
+    const button = screen.getByRole('button', { name: 'Outline' })
+    
+    expect(button).toHaveClass('border-2', 'border-purple-600', 'text-purple-600')
+  })
+
+  it('renders with danger variant', () => {
+    render(<Button variant="danger">Danger</Button>)
+    const button = screen.getByRole('button', { name: 'Danger' })
+    
+    expect(button).toHaveClass('bg-red-600', 'text-white')
+  })
+
+  it('renders loading state with disabled button and spinner', () => {
+    render(<Button loading>Loading</Button>)
+    const button = screen.getByRole('button', { name: 'Loading' })
+    
+    expect(button).toBeDisabled()
+    expect(button.querySelector('svg.animate-spin')).toBeInTheDocument()
   })
 
   it('applies custom className', () => {


### PR DESCRIPTION
## Summary

Fixes #571.

Previously, `src/components/__tests__/Button.test.tsx` was asserting against legacy color tokens (`bg-sunrise`, `bg-wave`, `bg-transparent border border-ink/20`) rather than the active design system classes in `src/components/Button.tsx`.

### Changes
- Updated `Button.test.tsx` variant assertions to match the design system tokens (`bg-purple-600`, `bg-gray-200`, `hover:bg-gray-100`).
- Added test coverage for `outline` (`border-2 border-purple-600`), `danger` (`bg-red-600`), and `loading` (disabled + spinner) button variants.

### Verification
- Tested with Vitest: `13 passed, 0 failed` (100% pass rate).
