### PR TITLE
fix(types): replace empty interfaces with typed WebXR contracts and type alias

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -434,7 +434,7 @@ export async function searchCreatorsByTag(query: string): Promise<CreatorProfile
   }
 }
 
-export interface CreatorWithCategoriesTags extends CreatorProfile {} // for type consistency
+export type CreatorWithCategoriesTags = CreatorProfile;
 
 // ─── Categories & Tags ──────────────────────────────────────────────────────
 

--- a/src/types/web-apis.d.ts
+++ b/src/types/web-apis.d.ts
@@ -5,7 +5,10 @@ interface BeforeInstallPromptEvent extends Event {
 
 type XRSessionMode = "immersive-ar";
 type XRReferenceSpaceType = "local" | "viewer";
-interface XRReferenceSpace {}
+interface XRReferenceSpace extends EventTarget {
+  getOffsetReferenceSpace(originOffset?: unknown): XRReferenceSpace;
+  onreset?: ((this: XRReferenceSpace, ev: Event) => unknown) | null;
+}
 interface XRHitTestSource { cancel(): void; }
 interface XRFrame { getHitTestResults(source: XRHitTestSource): unknown[]; }
 interface XRSession extends EventTarget {


### PR DESCRIPTION
Closes #566

### Summary of Changes
1. **Typed WebXR Reference Space**: Updated \XRReferenceSpace\ in \src/types/web-apis.d.ts\ to inherit from \EventTarget\ and declare \getOffsetReferenceSpace(originOffset?: unknown): XRReferenceSpace\ and optional \onreset\ event listener, replacing the unconstrained empty interface with the standard WebXR Device API contract.
2. **Type Alias for CreatorWithCategoriesTags**: Replaced empty interface extending \CreatorProfile\ in \src/services/api.ts\ with \export type CreatorWithCategoriesTags = CreatorProfile;\, avoiding unnecessary interface inheritance and satisfying TypeScript ESLint \@typescript-eslint/no-empty-object-type\.

### Verification
- Validated clean TypeScript compilation with \	sc --noEmit\.
- All affected ambient and service type declarations remain fully backwards-compatible across the codebase.
