### PR TITLE
test(wallet): wrap useWallet test in WalletProvider context

### DIFF
--- a/src/hooks/__tests__/useWallet.test.ts
+++ b/src/hooks/__tests__/useWallet.test.ts
@@ -1,6 +1,11 @@
+import React from 'react'
 import { renderHook, act } from '@testing-library/react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { WalletProvider } from '@/contexts/WalletContext'
 import { useWallet } from '../useWallet'
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(WalletProvider, null, children)
 
 describe('useWallet Hook', () => {
   beforeEach(() => {
@@ -9,28 +14,28 @@ describe('useWallet Hook', () => {
   })
 
   it('should initialize with disconnected state', () => {
-    const { result } = renderHook(() => useWallet())
+    const { result } = renderHook(() => useWallet(), { wrapper })
 
     expect(result.current.isConnected).toBe(false)
     expect(result.current.publicKey).toBeNull()
   })
 
   it('should have connect method', () => {
-    const { result } = renderHook(() => useWallet())
+    const { result } = renderHook(() => useWallet(), { wrapper })
 
     expect(result.current.connect).toBeDefined()
     expect(typeof result.current.connect).toBe('function')
   })
 
   it('should have disconnect method', () => {
-    const { result } = renderHook(() => useWallet())
+    const { result } = renderHook(() => useWallet(), { wrapper })
 
     expect(result.current.disconnect).toBeDefined()
     expect(typeof result.current.disconnect).toBe('function')
   })
 
   it('should handle wallet connection', async () => {
-    const { result } = renderHook(() => useWallet())
+    const { result } = renderHook(() => useWallet(), { wrapper })
 
     expect(result.current.isConnected).toBe(false)
 
@@ -44,7 +49,7 @@ describe('useWallet Hook', () => {
   })
 
   it('should persist wallet state', () => {
-    const { result } = renderHook(() => useWallet())
+    const { result } = renderHook(() => useWallet(), { wrapper })
 
     act(() => {
       // Simulate wallet connection
@@ -56,8 +61,9 @@ describe('useWallet Hook', () => {
   })
 
   it('should handle wallet errors', async () => {
-    const { result } = renderHook(() => useWallet())
+    const { result } = renderHook(() => useWallet(), { wrapper })
 
     expect(result.current.error).toBeNull()
   })
 })
+


### PR DESCRIPTION
Closes #560

### Summary of Changes
1. **WalletProvider Context Wrapper**: Added a React \WalletProvider\ test wrapper to \src/hooks/__tests__/useWallet.test.ts\ via \enderHook(() => useWallet(), { wrapper })\, allowing \useWallet()\ to access its required \WalletContext\ and exercise its underlying state machine.

### Verification
- Executed Vitest test suite for \useWallet.test.ts\:
  \\\ash
  npx vitest run src/hooks/__tests__/useWallet.test.ts
  # 1 passed (1), 6 tests passed (6/6, 100%)
  \\\
- Verified clean TypeScript compilation with \
px tsc --noEmit\.
