### PR TITLE
test(notifications): replace explicit any casts with typed NotificationSettings input

### DIFF
--- a/src/services/__tests__/notificationService.test.ts
+++ b/src/services/__tests__/notificationService.test.ts
@@ -8,6 +8,31 @@ function wrapEnv(data: unknown): string {
   return JSON.stringify({ __v: 1, d: data });
 }
 
+const createStorageMock = () => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+};
+
+const storageMock = createStorageMock();
+if (typeof globalThis.localStorage === "undefined" || !globalThis.localStorage.clear) {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: storageMock,
+    writable: true,
+    configurable: true,
+  });
+}
+
 describe("Notification Service", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -154,7 +179,9 @@ describe("Notification Service", () => {
       };
 
       await expect(
-        notificationService.updateNotificationSettings(invalidSettings as any)
+        notificationService.updateNotificationSettings(
+          invalidSettings as unknown as NotificationSettings
+        )
       ).rejects.toThrow();
     });
 
@@ -178,7 +205,9 @@ describe("Notification Service", () => {
       };
 
       await expect(
-        notificationService.updateNotificationSettings(invalidSettings as any)
+        notificationService.updateNotificationSettings(
+          invalidSettings as unknown as NotificationSettings
+        )
       ).rejects.toThrow();
     });
   });


### PR DESCRIPTION
Closes #585

### Summary of Changes
1. **Type-Safe Test Assertions**: Replaced explicit \s any\ casts at lines 157 and 181 in \src/services/__tests__/notificationService.test.ts\ with \invalidSettings as unknown as NotificationSettings\, maintaining strict TypeScript typing during error condition verification.
2. **Resilient LocalStorage Setup**: Included fallback \localStorage\ mock instantiation for non-browser/Node test environments to prevent unhandled \clear()\ exceptions.

### Verification
- Executed Vitest test suite for \
otificationService.test.ts\:
  \\\ash
  npx vitest run src/services/__tests__/notificationService.test.ts
  # 1 passed (1), 34 tests passed (34/34, 100%)
  \\\
- Verified clean TypeScript compilation with \
px tsc --noEmit\.
