### PR TITLE
fix(notifications): strongly type notification store metadata and state merge

### DIFF
--- a/src/store/__tests__/notificationStore.test.ts
+++ b/src/store/__tests__/notificationStore.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useNotificationStore } from "@/store/notificationStore";
+
+describe("useNotificationStore", () => {
+  beforeEach(() => {
+    useNotificationStore.setState({
+      notifications: [],
+      isOpen: false,
+    });
+  });
+
+  it("adds notifications with generated id and unread status", () => {
+    useNotificationStore.getState().addNotification({
+      type: "tip",
+      title: "New Tip Received",
+      description: "You received 50 XLM",
+      metadata: { amount: 50, currency: "XLM" },
+    });
+
+    const notifs = useNotificationStore.getState().notifications;
+    expect(notifs).toHaveLength(1);
+    expect(notifs[0].title).toBe("New Tip Received");
+    expect(notifs[0].read).toBe(false);
+    expect(notifs[0].type).toBe("tip");
+    expect(notifs[0].metadata).toEqual({ amount: 50, currency: "XLM" });
+    expect(useNotificationStore.getState().getUnreadCount()).toBe(1);
+  });
+
+  it("marks a notification as read", () => {
+    useNotificationStore.getState().addNotification({
+      type: "follower",
+      title: "New Follower",
+      description: "Alice is now following you",
+    });
+
+    const id = useNotificationStore.getState().notifications[0].id;
+    useNotificationStore.getState().markAsRead(id);
+
+    expect(useNotificationStore.getState().notifications[0].read).toBe(true);
+    expect(useNotificationStore.getState().getUnreadCount()).toBe(0);
+  });
+
+  it("marks all notifications as read", () => {
+    useNotificationStore.getState().addNotification({
+      type: "tip",
+      title: "Tip 1",
+      description: "10 XLM",
+    });
+    useNotificationStore.getState().addNotification({
+      type: "milestone",
+      title: "Milestone reached",
+      description: "100 tips reached",
+    });
+
+    expect(useNotificationStore.getState().getUnreadCount()).toBe(2);
+
+    useNotificationStore.getState().markAllAsRead();
+
+    expect(useNotificationStore.getState().getUnreadCount()).toBe(0);
+    expect(useNotificationStore.getState().notifications.every((n) => n.read)).toBe(true);
+  });
+
+  it("removes a notification by id", () => {
+    useNotificationStore.getState().addNotification({
+      type: "tip",
+      title: "Tip 1",
+      description: "10 XLM",
+    });
+    const id = useNotificationStore.getState().notifications[0].id;
+
+    useNotificationStore.getState().removeNotification(id);
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+
+  it("toggles isOpen state", () => {
+    expect(useNotificationStore.getState().isOpen).toBe(false);
+    useNotificationStore.getState().setOpen(true);
+    expect(useNotificationStore.getState().isOpen).toBe(true);
+  });
+});

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -18,7 +18,22 @@ export interface Notification {
   timestamp: Date;
   read: boolean;
   link?: string;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
+}
+
+interface PersistedNotification {
+  id: string;
+  type: NotificationType;
+  title: string;
+  description: string;
+  timestamp: string | Date;
+  read: boolean;
+  link?: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface PersistedNotificationStoreState {
+  notifications?: PersistedNotification[];
 }
 
 interface NotificationStoreState {
@@ -139,14 +154,15 @@ export const useNotificationStore = create<NotificationStoreState>()(
         if (
           persistedState &&
           typeof persistedState === "object" &&
-          "notifications" in persistedState
+          "notifications" in persistedState &&
+          Array.isArray((persistedState as PersistedNotificationStoreState).notifications)
         ) {
-          const notifs = (persistedState as any).notifications.map(
-            (n: any) => ({
-              ...n,
-              timestamp: new Date(n.timestamp),
-            }),
-          );
+          const rawNotifications =
+            (persistedState as PersistedNotificationStoreState).notifications ?? [];
+          const notifs: Notification[] = rawNotifications.map((n) => ({
+            ...n,
+            timestamp: new Date(n.timestamp),
+          }));
           return {
             ...currentState,
             notifications: notifs,


### PR DESCRIPTION
Closes #584

### Summary of Changes
1. **Type-Safe Notification Metadata**: Replaced \metadata?: Record<string, any>\ in \Notification\ with type-safe \metadata?: Record<string, unknown>\ to prevent untyped state drift across consumers.
2. **Typed Store Persistence & Merge**: Defined \PersistedNotification\ and \PersistedNotificationStoreState\ interfaces, replacing unconstrained \ny\ casts in the Zustand \merge\ lifecycle callback with runtime array checks and type annotations.
3. **Unit Test Coverage**: Added comprehensive test suite in \src/store/__tests__/notificationStore.test.ts\ verifying notification creation, unread count tracking, state mutation, and store toggles.

### Verification
- Executed Vitest test suite for \
otificationStore.test.ts\:
  \\\ash
  npx vitest run src/store/__tests__/notificationStore.test.ts
  # 1 passed (1), 5 tests passed (5/5, 100%)
  \\\
- Verified clean TypeScript compilation with \
px tsc --noEmit\.
