### PR TITLE
fix(speech): type Web Speech API interfaces and eliminate any casts

### DIFF
--- a/src/types/web-apis.d.ts
+++ b/src/types/web-apis.d.ts
@@ -21,3 +21,55 @@ interface XRSystem {
 }
 interface Navigator { xr?: XRSystem; }
 interface ServiceWorkerRegistration { sync?: { register(tag: string): Promise<void> }; }
+
+interface SpeechRecognitionAlternative {
+  transcript: string;
+  confidence: number;
+}
+
+interface SpeechRecognitionResultItem {
+  readonly length: number;
+  item(index: number): SpeechRecognitionAlternative;
+  [index: number]: SpeechRecognitionAlternative;
+  isFinal: boolean;
+}
+
+interface SpeechRecognitionResultList {
+  readonly length: number;
+  item(index: number): SpeechRecognitionResultItem;
+  [index: number]: SpeechRecognitionResultItem;
+}
+
+interface SpeechRecognitionEvent extends Event {
+  resultIndex: number;
+  results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionErrorEvent extends Event {
+  error: string;
+  message?: string;
+}
+
+interface ISpeechRecognition extends EventTarget {
+  language: string;
+  continuous: boolean;
+  interimResults: boolean;
+  maxAlternatives: number;
+  onstart: ((this: ISpeechRecognition, ev: Event) => void) | null;
+  onresult: ((this: ISpeechRecognition, ev: SpeechRecognitionEvent) => void) | null;
+  onerror: ((this: ISpeechRecognition, ev: SpeechRecognitionErrorEvent) => void) | null;
+  onend: ((this: ISpeechRecognition, ev: Event) => void) | null;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+interface Window {
+  SpeechRecognition?: {
+    new (): ISpeechRecognition;
+  };
+  webkitSpeechRecognition?: {
+    new (): ISpeechRecognition;
+  };
+}
+

--- a/src/utils/speechRecognition.ts
+++ b/src/utils/speechRecognition.ts
@@ -17,18 +17,18 @@ export interface SpeechRecognitionOptions {
 }
 
 class SpeechRecognitionService {
-  private recognition: any;
+  private recognition: ISpeechRecognition | undefined;
   private isListening = false;
   private isSpeaking = false;
 
   constructor() {
-    const SpeechRecognition =
-      typeof window !== 'undefined' &&
-      ((window as any).SpeechRecognition ||
-        (window as any).webkitSpeechRecognition);
+    const SpeechRecognitionClass =
+      typeof window !== 'undefined'
+        ? window.SpeechRecognition || window.webkitSpeechRecognition
+        : undefined;
 
-    if (SpeechRecognition) {
-      this.recognition = new SpeechRecognition();
+    if (SpeechRecognitionClass) {
+      this.recognition = new SpeechRecognitionClass();
     }
   }
 
@@ -41,7 +41,7 @@ class SpeechRecognitionService {
     onError?: (error: string) => void,
     options?: SpeechRecognitionOptions
   ): void {
-    if (!this.isSupported()) {
+    if (!this.recognition) {
       onError?.('Speech recognition not supported in this browser');
       return;
     }
@@ -56,7 +56,7 @@ class SpeechRecognitionService {
       this.isListening = true;
     };
 
-    this.recognition.onresult = (event: any) => {
+    this.recognition.onresult = (event: SpeechRecognitionEvent) => {
       let transcript = '';
       let confidence = 0;
 
@@ -75,7 +75,7 @@ class SpeechRecognitionService {
       });
     };
 
-    this.recognition.onerror = (event: any) => {
+    this.recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
       onError?.(event.error);
     };
 
@@ -87,7 +87,7 @@ class SpeechRecognitionService {
   }
 
   stopListening(): void {
-    if (this.isSupported() && this.isListening) {
+    if (this.recognition && this.isListening) {
       this.recognition.stop();
       this.isListening = false;
     }


### PR DESCRIPTION
Closes #583

### Summary of Changes
1. **Web Speech Ambient Type Declarations**: Added type definitions for \ISpeechRecognition\, \SpeechRecognitionAlternative\, \SpeechRecognitionResultItem\, \SpeechRecognitionResultList\, \SpeechRecognitionEvent\, and \SpeechRecognitionErrorEvent\ in \src/types/web-apis.d.ts\, extending \Window\ with vendor-prefixed constructors.
2. **Type-Safe Speech Recognition Service**: Refactored \src/utils/speechRecognition.ts\ to type \	his.recognition\ as \ISpeechRecognition | undefined\ and annotate \onresult\ / \onerror\ handlers with explicit event interfaces, eliminating 5 unconstrained \ny\ casts.

### Verification
- Executed Vitest test suite for \useVoiceCommands.test.tsx\:
  \\\ash
  npx vitest run src/hooks/__tests__/useVoiceCommands.test.tsx
  # 1 passed (1), 14 tests passed (14/14, 100%)
  \\\
- Verified clean TypeScript compilation with \
px tsc --noEmit\.
