### PR TITLE
feat(config): enforce build/startup validation in next.config.ts and add test suite

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 import createBundleAnalyzer from "@next/bundle-analyzer";
 import { getSecurityHeaders } from "./src/utils/security";
+import "./src/config/env";
 
 const withNextIntl = createNextIntlPlugin("./src/i18n.ts");
 const withBundleAnalyzer = createBundleAnalyzer({

--- a/src/config/__tests__/env.test.ts
+++ b/src/config/__tests__/env.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { AppConfigSchema, loadConfig, appConfig } from "@/config/env";
+
+describe("AppConfig and Environment Validation", () => {
+  it("loads valid default configuration", () => {
+    expect(appConfig).toBeDefined();
+    expect(appConfig.apiUrl).toMatch(/^https?:\/\//);
+    expect(appConfig.wsUrl).toMatch(/^wss?:\/\//);
+    expect(["TESTNET", "PUBLIC"]).toContain(appConfig.stellarNetwork);
+  });
+
+  it("successfully parses valid custom environment variables", () => {
+    const valid = {
+      NEXT_PUBLIC_API_URL: "https://api.example.com",
+      NEXT_PUBLIC_WS_URL: "wss://ws.example.com",
+      NEXT_PUBLIC_STELLAR_NETWORK: "public",
+      NEXT_PUBLIC_SITE_URL: "https://example.com",
+      NODE_ENV: "production",
+    };
+
+    const parsed = loadConfig(valid);
+    expect(parsed.apiUrl).toBe("https://api.example.com");
+    expect(parsed.wsUrl).toBe("wss://ws.example.com");
+    expect(parsed.stellarNetwork).toBe("PUBLIC");
+  });
+
+  it("throws fail-fast descriptive error on invalid URLs", () => {
+    const invalid = {
+      NEXT_PUBLIC_API_URL: "not-a-valid-url",
+      NEXT_PUBLIC_WS_URL: "not-a-valid-ws",
+      NEXT_PUBLIC_STELLAR_NETWORK: "invalid_net",
+      NODE_ENV: "production",
+    };
+
+    expect(() => loadConfig(invalid)).toThrowError(/\[AppConfig\] Application configuration is invalid/);
+  });
+
+  it("transforms lowercase stellar network to uppercase", () => {
+    const parsed = AppConfigSchema.parse({
+      stellarNetwork: "testnet",
+    });
+    expect(parsed.stellarNetwork).toBe("TESTNET");
+  });
+});

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -17,7 +17,7 @@ import { z } from "zod";
 
 const stellarNetworkEnum = z.enum(["testnet", "public", "TESTNET", "PUBLIC"]);
 
-const AppConfigSchema = z.object({
+export const AppConfigSchema = z.object({
   // API
   apiUrl: z
     .string()
@@ -70,18 +70,18 @@ export type AppConfig = z.infer<typeof AppConfigSchema>;
 // Loader — runs once at module load
 // ---------------------------------------------------------------------------
 
-function loadConfig(): AppConfig {
+export function loadConfig(customEnv?: Record<string, string | undefined>): AppConfig {
   const raw = {
-    apiUrl: process.env.NEXT_PUBLIC_API_URL,
-    wsUrl: process.env.NEXT_PUBLIC_WS_URL,
-    stellarNetwork: process.env.NEXT_PUBLIC_STELLAR_NETWORK,
-    stellarHorizonUrl: process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL,
-    siteUrl: process.env.NEXT_PUBLIC_SITE_URL,
-    appUrl: process.env.NEXT_PUBLIC_APP_URL,
-    gaId: process.env.NEXT_PUBLIC_GA_ID,
-    sentryDsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-    vapidPublicKey: process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY,
-    nodeEnv: process.env.NODE_ENV,
+    apiUrl: customEnv?.NEXT_PUBLIC_API_URL ?? process.env.NEXT_PUBLIC_API_URL,
+    wsUrl: customEnv?.NEXT_PUBLIC_WS_URL ?? process.env.NEXT_PUBLIC_WS_URL,
+    stellarNetwork: customEnv?.NEXT_PUBLIC_STELLAR_NETWORK ?? process.env.NEXT_PUBLIC_STELLAR_NETWORK,
+    stellarHorizonUrl: customEnv?.NEXT_PUBLIC_STELLAR_HORIZON_URL ?? process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL,
+    siteUrl: customEnv?.NEXT_PUBLIC_SITE_URL ?? process.env.NEXT_PUBLIC_SITE_URL,
+    appUrl: customEnv?.NEXT_PUBLIC_APP_URL ?? process.env.NEXT_PUBLIC_APP_URL,
+    gaId: customEnv?.NEXT_PUBLIC_GA_ID ?? process.env.NEXT_PUBLIC_GA_ID,
+    sentryDsn: customEnv?.NEXT_PUBLIC_SENTRY_DSN ?? process.env.NEXT_PUBLIC_SENTRY_DSN,
+    vapidPublicKey: customEnv?.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY,
+    nodeEnv: customEnv?.NODE_ENV ?? process.env.NODE_ENV,
   };
 
   const result = AppConfigSchema.safeParse(raw);


### PR DESCRIPTION
Closes #580

### Summary of Changes
1. **Build & Server Startup Fail-Fast Validation**: Added \import \"./src/config/env\";\ to \
ext.config.ts\ ensuring that \AppConfig\ schema validation executes eagerly at Next.js build and development server initialization time, preventing deployment or execution with invalid environment parameters.
2. **Flexible Configuration Loader**: Exported \AppConfigSchema\ and \loadConfig(customEnv?)\ from \src/config/env.ts\ to enable parameterized validation in tests and isolated scripts without altering global process environment state.
3. **Automated Unit Tests**: Added unit tests in \src/config/__tests__/env.test.ts\ verifying default configuration loading, custom environment parsing, network enum normalization, and fail-fast aggregate error messages on invalid URLs.

### Verification
- Executed Vitest test suite for \env.test.ts\:
  \\\ash
  npx vitest run src/config/__tests__/env.test.ts
  # 1 passed (1), 4 tests passed (4/4, 100%)
  \\\
- Verified clean TypeScript compilation with \
px tsc --noEmit\.
