### PR TITLE
fix(i18n): preserve deep route path when switching locales and add unit tests

### DIFF
--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -15,6 +15,16 @@ const languages = [
   { code: "ar", name: "العربية", flag: "🇸🇦" },
 ];
 
+export function getLocalizedPath(pathname: string, newLocale: string): string {
+  const segments = pathname.split("/").filter(Boolean);
+  const knownLocales = languages.map((l) => l.code);
+  if (knownLocales.includes(segments[0])) {
+    segments.shift();
+  }
+  const cleanPath = segments.length > 0 ? `/${segments.join("/")}` : "";
+  return newLocale === "en" ? cleanPath || "/" : `/${newLocale}${cleanPath}`;
+}
+
 export function LanguageSwitcher() {
   const router = useRouter();
   const pathname = usePathname();
@@ -25,13 +35,7 @@ export function LanguageSwitcher() {
     storage.setString("locale", newLocale);
 
     startTransition(() => {
-      // Strip existing locale prefix and prepend new one
-      const segments = pathname.split("/");
-      const knownLocales = languages.map((l) => l.code);
-      if (knownLocales.includes(segments[1])) {
-        segments.splice(1, 1);
-      }
-      const newPath = newLocale === "en" ? segments.join("/") || "/" : `/${newLocale}${segments.join("/")}`;
+      const newPath = getLocalizedPath(pathname, newLocale);
       router.replace(newPath as any);
     });
   };

--- a/src/components/__tests__/LanguageSwitcher.test.tsx
+++ b/src/components/__tests__/LanguageSwitcher.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { LanguageSwitcher, getLocalizedPath } from "../LanguageSwitcher";
+
+const mockReplace = vi.fn();
+let mockPathname = "/";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  usePathname: () => mockPathname,
+}));
+
+vi.mock("next-intl", () => ({
+  useLocale: () => "en",
+}));
+
+describe("LanguageSwitcher & getLocalizedPath", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPathname = "/";
+  });
+
+  describe("getLocalizedPath utility", () => {
+    it("preserves nested paths when switching to non-default locales", () => {
+      expect(getLocalizedPath("/creator/alice", "es")).toBe("/es/creator/alice");
+      expect(getLocalizedPath("/creator/alice/settings", "fr")).toBe("/fr/creator/alice/settings");
+      expect(getLocalizedPath("/explore", "zh")).toBe("/zh/explore");
+    });
+
+    it("strips locale prefix when switching back to default English", () => {
+      expect(getLocalizedPath("/es/creator/alice", "en")).toBe("/creator/alice");
+      expect(getLocalizedPath("/fr/explore", "en")).toBe("/explore");
+      expect(getLocalizedPath("/zh", "en")).toBe("/");
+    });
+
+    it("swaps existing locale prefix when switching between non-default locales", () => {
+      expect(getLocalizedPath("/es/creator/alice", "fr")).toBe("/fr/creator/alice");
+      expect(getLocalizedPath("/zh/tips", "ar")).toBe("/ar/tips");
+    });
+
+    it("handles root path correctly without trailing slash bugs", () => {
+      expect(getLocalizedPath("/", "es")).toBe("/es");
+      expect(getLocalizedPath("/", "en")).toBe("/");
+    });
+  });
+
+  describe("LanguageSwitcher component", () => {
+    it("renders language select dropdown with accessibility label", () => {
+      render(<LanguageSwitcher />);
+      const select = screen.getByRole("combobox", { name: /select language/i });
+      expect(select).toBeInTheDocument();
+      expect(select).toHaveValue("en");
+    });
+
+    it("calls router.replace with preserved deep path on selection", () => {
+      mockPathname = "/creators/bob";
+      render(<LanguageSwitcher />);
+
+      const select = screen.getByRole("combobox", { name: /select language/i });
+      fireEvent.change(select, { target: { value: "es" } });
+
+      expect(mockReplace).toHaveBeenCalledWith("/es/creators/bob");
+    });
+  });
+});


### PR DESCRIPTION
Closes #597

### Summary of Changes
1. **Deep Route Preservation on Locale Switch**: Added \getLocalizedPath(pathname, newLocale)\ helper to \src/components/LanguageSwitcher.tsx\ to reliably extract and swap locale prefixes while preserving nested sub-paths (e.g. \/fr/creator/alice\ -> \/zh/creator/alice\, \/es/explore\ -> \/explore\) and preventing trailing-slash artifacts on root transitions.
2. **Automated Unit Tests**: Added unit tests in \src/components/__tests__/LanguageSwitcher.test.tsx\ verifying pathname translation behavior across default and localized routes, as well as router replacement upon language selection.

### Verification
- Executed Vitest test suite for \LanguageSwitcher.test.tsx\:
  \\\ash
  npx vitest run src/components/__tests__/LanguageSwitcher.test.tsx
  # 1 passed (1), 6 tests passed (6/6, 100%)
  \\\
- Verified clean TypeScript compilation with \
px tsc --noEmit\.
