### PR TITLE
feat(security): harden CSP directives against XSS and add security test suite

### DIFF
--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -1,18 +1,59 @@
-// Content Security Policy builder
+import { IS_DEV } from "@/config/env";
 
-export function buildCspHeader() {
+export interface CspOptions {
+  isDev?: boolean;
+  nonce?: string;
+}
+
+export function buildCspHeader(options: CspOptions = {}): string {
+  const isDev = options.isDev ?? IS_DEV;
+
+  const scriptDirectives = [
+    "'self'",
+    options.nonce ? `'nonce-${options.nonce}'` : null,
+    isDev ? "'unsafe-eval'" : null,
+    "'wasm-unsafe-eval'",
+  ].filter(Boolean);
+
+  const styleDirectives = ["'self'", "'unsafe-inline'"];
+
+  const connectDirectives = [
+    "'self'",
+    "https:",
+    "wss:",
+    isDev ? "http:" : null,
+    isDev ? "ws:" : null,
+  ].filter(Boolean);
+
+  const imgDirectives = [
+    "'self'",
+    "data:",
+    "blob:",
+    "https:",
+    isDev ? "http:" : null,
+  ].filter(Boolean);
+
+  const mediaDirectives = [
+    "'self'",
+    "blob:",
+    "https:",
+    isDev ? "http:" : null,
+  ].filter(Boolean);
+
   return [
     "default-src 'self'",
-    "script-src 'self' 'unsafe-eval' 'unsafe-inline' 'wasm-unsafe-eval'",
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data: blob: https: http:",
+    `script-src ${scriptDirectives.join(" ")}`,
+    `style-src ${styleDirectives.join(" ")}`,
+    `img-src ${imgDirectives.join(" ")}`,
     "font-src 'self' data:",
-    "connect-src 'self' https: http: ws: wss:",
-    "media-src 'self' blob: https: http:",
+    `connect-src ${connectDirectives.join(" ")}`,
+    `media-src ${mediaDirectives.join(" ")}`,
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'self'",
     "frame-ancestors 'none'",
-  ].join('; ');
+    ...(isDev ? [] : ["upgrade-insecure-requests", "block-all-mixed-content"]),
+  ].join("; ");
 }
+
 

--- a/src/utils/__tests__/security.test.ts
+++ b/src/utils/__tests__/security.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { buildCspHeader } from "@/lib/csp";
+import { getSecurityHeaders } from "../security";
+
+describe("Security Headers & CSP Verification", () => {
+  describe("buildCspHeader", () => {
+    it("enforces strict production CSP directives without unsafe-eval", () => {
+      const csp = buildCspHeader({ isDev: false });
+
+      expect(csp).toContain("default-src 'self'");
+      expect(csp).toContain("script-src 'self' 'wasm-unsafe-eval'");
+      expect(csp).not.toContain("'unsafe-eval'");
+      expect(csp).toContain("object-src 'none'");
+      expect(csp).toContain("base-uri 'self'");
+      expect(csp).toContain("frame-ancestors 'none'");
+      expect(csp).toContain("upgrade-insecure-requests");
+      expect(csp).toContain("block-all-mixed-content");
+    });
+
+    it("supports nonce injection for inline scripts", () => {
+      const csp = buildCspHeader({ nonce: "rAnd0mN0nc3", isDev: false });
+      expect(csp).toContain("'nonce-rAnd0mN0nc3'");
+    });
+
+    it("allows dev-specific evaluation only when isDev is true", () => {
+      const devCsp = buildCspHeader({ isDev: true });
+      expect(devCsp).toContain("'unsafe-eval'");
+      expect(devCsp).not.toContain("upgrade-insecure-requests");
+    });
+  });
+
+  describe("getSecurityHeaders", () => {
+    it("returns complete hardened HTTP security header suite", () => {
+      const headers = getSecurityHeaders({ isDev: false });
+      const map = Object.fromEntries(headers.map((h) => [h.key, h.value]));
+
+      expect(map["Content-Security-Policy"]).toBeDefined();
+      expect(map["Strict-Transport-Security"]).toBe("max-age=63072000; includeSubDomains; preload");
+      expect(map["X-Frame-Options"]).toBe("DENY");
+      expect(map["X-Content-Type-Options"]).toBe("nosniff");
+      expect(map["Referrer-Policy"]).toBe("strict-origin-when-cross-origin");
+      expect(map["Permissions-Policy"]).toContain("camera=(), microphone=()");
+    });
+  });
+});

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -5,7 +5,7 @@
  * in both next.config.ts (static headers) and src/middleware.ts (dynamic headers).
  */
 
-import { buildCspHeader } from "../lib/csp";
+import { buildCspHeader, type CspOptions } from "../lib/csp";
 
 export interface SecurityHeader {
   key: string;
@@ -16,11 +16,11 @@ export interface SecurityHeader {
  * Returns the complete list of security headers to apply to every response.
  * Call this at build-time (next.config.ts) or at request-time (middleware).
  */
-export function getSecurityHeaders(): SecurityHeader[] {
+export function getSecurityHeaders(options?: CspOptions): SecurityHeader[] {
   return [
     {
       key: "Content-Security-Policy",
-      value: buildCspHeader(),
+      value: buildCspHeader(options),
     },
     {
       // 2-year max-age; includeSubDomains + preload for HSTS preload list eligibility


### PR DESCRIPTION
Closes #596

### Summary of Changes
1. **Hardened Production CSP Directives**: Refactored \src/lib/csp.ts\ to construct environment-aware Content-Security-Policy headers. In production, \'unsafe-eval'\ and insecure plain-\http:\ origin fallbacks are omitted, while strictly enforcing \upgrade-insecure-requests\, \lock-all-mixed-content\, \object-src 'none'\, \ase-uri 'self'\, and \rame-ancestors 'none'\.
2. **Dynamic Nonce & Dev Mode Support**: Added \CspOptions\ interface supporting optional cryptographic nonces (\'nonce-xxx'\) for inline scripts and enabling dev-only tooling when running in development environments.
3. **Automated Unit Tests**: Added unit test suite in \src/utils/__tests__/security.test.ts\ verifying production strictness, nonce formatting, dev isolation, and full HTTP security header compliance (\HSTS\, \X-Frame-Options: DENY\, \X-Content-Type-Options: nosniff\, \Permissions-Policy\).

### Verification
- Executed Vitest test suite for \security.test.ts\:
  \\\ash
  npx vitest run src/utils/__tests__/security.test.ts
  # 1 passed (1), 4 tests passed (4/4, 100%)
  \\\
- Verified clean TypeScript compilation with \
px tsc --noEmit\.
