### PR TITLE
ci: wire check:bundle-budget into primary CI build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,3 +137,7 @@ jobs:
 
       - name: Build Next.js app
         run: npm run build
+
+      - name: Check bundle budget
+        run: npm run check:bundle-budget
+


### PR DESCRIPTION
Closes #604

### Summary of Changes
1. **Primary CI Bundle Budget Enforcement**: Wired \
pm run check:bundle-budget\ directly into the \uild\ job of \.github/workflows/ci.yml\ following \
ext build\, guaranteeing that pull requests and main pushes fail automatically if shared First Load JS exceeds the 190 KB gzip budget.
2. **Eliminated CI Duplication**: Consolidated bundle budget verification within the main CI workflow alongside linting, typechecking, and test suites.

### Verification
- Verified workflow YAML syntax and step order in \.github/workflows/ci.yml\.
- Tested \
pm run check:bundle-budget\ locally against Next.js production build output.
