### PR TITLE
feat(mentorship): wire get selectors, clean type imports, and add test suite for useMentorshipStore

### DIFF
--- a/src/store/__tests__/useMentorshipStore.test.ts
+++ b/src/store/__tests__/useMentorshipStore.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useMentorshipStore } from '../useMentorshipStore';
+
+describe('useMentorshipStore', () => {
+  beforeEach(() => {
+    useMentorshipStore.setState({ sessions: [], messages: [] });
+  });
+
+  it('creates and tracks new mentorship sessions with default milestones', () => {
+    const store = useMentorshipStore.getState();
+    const sessionId = store.requestMentorship('mentor-alice', 'mentee-bob');
+
+    const session = useMentorshipStore.getState().getSessionById(sessionId);
+    expect(session).toBeDefined();
+    expect(session?.mentorId).toBe('mentor-alice');
+    expect(session?.menteeId).toBe('mentee-bob');
+    expect(session?.status).toBe('pending');
+    expect(session?.progress).toBe(0);
+    expect(session?.milestones).toHaveLength(4);
+  });
+
+  it('records messages and updates lastMessage on the corresponding session', () => {
+    const store = useMentorshipStore.getState();
+    const sessionId = store.requestMentorship('mentor-alice', 'mentee-bob');
+
+    store.sendMessage(sessionId, 'mentee-bob', 'Hello Alice!');
+
+    const messages = useMentorshipStore.getState().getMessagesBySessionId(sessionId);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].text).toBe('Hello Alice!');
+    expect(messages[0].senderId).toBe('mentee-bob');
+
+    const updatedSession = useMentorshipStore.getState().getSessionById(sessionId);
+    expect(updatedSession?.lastMessage).toBe('Hello Alice!');
+  });
+
+  it('completes milestones and recalculates session progress percentage', () => {
+    const store = useMentorshipStore.getState();
+    const sessionId = store.requestMentorship('mentor-alice', 'mentee-bob');
+
+    store.completeMilestone(sessionId, 0); // 1 out of 4 = 25%
+
+    let session = useMentorshipStore.getState().getSessionById(sessionId);
+    expect(session?.milestones[0].completed).toBe(true);
+    expect(session?.progress).toBe(25);
+
+    store.completeMilestone(sessionId, 1); // 2 out of 4 = 50%
+    session = useMentorshipStore.getState().getSessionById(sessionId);
+    expect(session?.progress).toBe(50);
+  });
+
+  it('updates overall progress manually when updateProgress is called', () => {
+    const store = useMentorshipStore.getState();
+    const sessionId = store.requestMentorship('mentor-alice', 'mentee-bob');
+
+    store.updateProgress(sessionId, 75);
+
+    const session = useMentorshipStore.getState().getSessionById(sessionId);
+    expect(session?.progress).toBe(75);
+  });
+});

--- a/src/store/useMentorshipStore.ts
+++ b/src/store/useMentorshipStore.ts
@@ -1,11 +1,13 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { createZustandStorage } from '@/lib/storage';
-import { Mentor, MentorshipSession, Message } from '@/lib/mentorship-data';
+import type { MentorshipSession, Message } from '@/lib/mentorship-data';
 
 interface MentorshipState {
   sessions: MentorshipSession[];
   messages: Message[];
+  getSessionById: (sessionId: string) => MentorshipSession | undefined;
+  getMessagesBySessionId: (sessionId: string) => Message[];
   requestMentorship: (mentorId: string, menteeId: string) => string;
   sendMessage: (sessionId: string, senderId: string, text: string) => void;
   updateProgress: (sessionId: string, progress: number) => void;
@@ -17,6 +19,8 @@ export const useMentorshipStore = create<MentorshipState>()(
     (set, get) => ({
       sessions: [],
       messages: [],
+      getSessionById: (sessionId) => get().sessions.find((s) => s.id === sessionId),
+      getMessagesBySessionId: (sessionId) => get().messages.filter((m) => m.sessionId === sessionId),
       requestMentorship: (mentorId, menteeId) => {
         const id = Math.random().toString(36).substr(2, 9);
         const newSession: MentorshipSession = {


### PR DESCRIPTION
Closes #606

### Summary of Changes
1. **Wired State Readers in \useMentorshipStore\**: Added \getSessionById(sessionId)\ and \getMessagesBySessionId(sessionId)\ getter selectors to \src/store/useMentorshipStore.ts\ leveraging Zustand's \get()\ callback for direct state reads.
2. **Clean Type Imports**: Removed unused \Mentor\ model import in favor of explicit \import type { MentorshipSession, Message }\.
3. **Automated Unit Tests**: Added unit tests in \src/store/__tests__/useMentorshipStore.test.ts\ verifying session initialization, message tracking, dynamic milestone completion, progress recalculation, and state reads.

### Verification
- Executed Vitest test suite for \useMentorshipStore.test.ts\:
  \\\ash
  npx vitest run src/store/__tests__/useMentorshipStore.test.ts
  # 1 passed (1), 4 tests passed (4/4, 100%)
  \\\
- Verified clean TypeScript compilation with \
px tsc --noEmit\.
