### PR TITLE
feat(app): add route segment-level error boundaries and logging context

### DIFF
--- a/src/app/__tests__/segmentErrorBoundaries.test.tsx
+++ b/src/app/__tests__/segmentErrorBoundaries.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import DashboardError from "../dashboard/error";
+import MarketplaceError from "../marketplace/error";
+import CreatorProfileError from "../creator/[username]/error";
+import MentorshipError from "../mentorship/error";
+import * as errorLogger from "@/utils/errorLogger";
+
+describe("Segment-Level Error Boundaries", () => {
+  const mockError = new Error("Failed to load segment data");
+  const mockReset = vi.fn();
+  const logErrorSpy = vi.spyOn(errorLogger, "logError").mockImplementation(() => {});
+
+  it("renders DashboardError fallback and handles reset", () => {
+    render(<DashboardError error={mockError} reset={mockReset} />);
+    expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+    expect(logErrorSpy).toHaveBeenCalledWith(mockError, expect.objectContaining({ context: "DashboardSegment" }));
+
+    const retryBtn = screen.getByRole("button", { name: /try again/i });
+    fireEvent.click(retryBtn);
+    expect(mockReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders MarketplaceError fallback and logs error", () => {
+    render(<MarketplaceError error={mockError} reset={mockReset} />);
+    expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+    expect(logErrorSpy).toHaveBeenCalledWith(mockError, expect.objectContaining({ context: "MarketplaceSegment" }));
+  });
+
+  it("renders CreatorProfileError fallback and logs error", () => {
+    render(<CreatorProfileError error={mockError} reset={mockReset} />);
+    expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+    expect(logErrorSpy).toHaveBeenCalledWith(mockError, expect.objectContaining({ context: "CreatorProfileSegment" }));
+  });
+
+  it("renders MentorshipError fallback and logs error", () => {
+    render(<MentorshipError error={mockError} reset={mockReset} />);
+    expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+    expect(logErrorSpy).toHaveBeenCalledWith(mockError, expect.objectContaining({ context: "MentorshipSegment" }));
+  });
+});

--- a/src/app/creator/[username]/error.tsx
+++ b/src/app/creator/[username]/error.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorFallback } from "@/components/ErrorFallback";
+import { logError } from "@/utils/errorLogger";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function CreatorProfileError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    logError(error, { context: "CreatorProfileSegment", digest: error.digest });
+  }, [error]);
+
+  return (
+    <div className="mx-auto max-w-4xl p-6">
+      <ErrorFallback
+        error={error}
+        reset={reset}
+        showDetails={process.env.NODE_ENV === "development"}
+      />
+    </div>
+  );
+}

--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorFallback } from "@/components/ErrorFallback";
+import { logError } from "@/utils/errorLogger";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function DashboardError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    logError(error, { context: "DashboardSegment", digest: error.digest });
+  }, [error]);
+
+  return (
+    <div className="mx-auto max-w-4xl p-6">
+      <ErrorFallback
+        error={error}
+        reset={reset}
+        showDetails={process.env.NODE_ENV === "development"}
+      />
+    </div>
+  );
+}

--- a/src/app/marketplace/error.tsx
+++ b/src/app/marketplace/error.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorFallback } from "@/components/ErrorFallback";
+import { logError } from "@/utils/errorLogger";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function MarketplaceError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    logError(error, { context: "MarketplaceSegment", digest: error.digest });
+  }, [error]);
+
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <ErrorFallback
+        error={error}
+        reset={reset}
+        showDetails={process.env.NODE_ENV === "development"}
+      />
+    </div>
+  );
+}

--- a/src/app/mentorship/error.tsx
+++ b/src/app/mentorship/error.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorFallback } from "@/components/ErrorFallback";
+import { logError } from "@/utils/errorLogger";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function MentorshipError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    logError(error, { context: "MentorshipSegment", digest: error.digest });
+  }, [error]);
+
+  return (
+    <div className="mx-auto max-w-4xl p-6">
+      <ErrorFallback
+        error={error}
+        reset={reset}
+        showDetails={process.env.NODE_ENV === "development"}
+      />
+    </div>
+  );
+}

--- a/src/utils/errorLogger.ts
+++ b/src/utils/errorLogger.ts
@@ -7,11 +7,12 @@
 export interface ErrorInfo {
   componentStack?: string;
   digest?: string;
+  context?: string;
 }
 
 export function logError(error: Error, info?: ErrorInfo): void {
   if (process.env.NODE_ENV === "development") {
-    console.group("[ErrorBoundary]");
+    console.group(`[ErrorBoundary${info?.context ? `: ${info.context}` : ""}]`);
     console.error("Error:", error);
     if (info?.componentStack) {
       console.error("Component stack:", info.componentStack);
@@ -28,6 +29,7 @@ export function logError(error: Error, info?: ErrorInfo): void {
     JSON.stringify({
       message: error.message,
       name: error.name,
+      context: info?.context,
       digest: info?.digest,
       timestamp: new Date().toISOString(),
     })


### PR DESCRIPTION
Closes #593

### Summary of Changes
1. **Segment-Level Error Boundaries**: Implemented nested \error.tsx\ boundaries for high-traffic dynamic route segments:
   - \src/app/dashboard/error.tsx\: Isolates analytics widget and card rendering failures.
   - \src/app/marketplace/error.tsx\: Isolates marketplace product catalog and checkout errors.
   - \src/app/creator/[username]/error.tsx\: Isolates creator profile metadata and tip goal rendering failures.
   - \src/app/mentorship/error.tsx\: Isolates mentorship chat and milestone loading errors.
2. **Contextual Error Logging**: Extended \ErrorInfo\ in \src/utils/errorLogger.ts\ with a \context\ parameter for structured, segment-tagged error diagnostics.
3. **Automated Unit Tests**: Added unit tests in \src/app/__tests__/segmentErrorBoundaries.test.tsx\ verifying that each segment boundary renders the error fallback, logs contextual tags, and handles retry (\eset\) actions.

### Verification
- Executed Vitest test suite for \segmentErrorBoundaries.test.tsx\:
  \\\ash
  npx vitest run src/app/__tests__/segmentErrorBoundaries.test.tsx
  # 1 passed (1), 4 tests passed (4/4, 100%)
  \\\
- Verified clean TypeScript compilation with \
px tsc --noEmit\.
