### PR TITLE
feat(workers): add abort handling, modular exports, and sync resilience test suite

### DIFF
--- a/src/workers/__tests__/syncWorker.test.ts
+++ b/src/workers/__tests__/syncWorker.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { executeAction, runSync, MAX_ATTEMPTS } from "../syncWorker";
+import * as offlineStorage from "@/utils/offlineStorage";
+
+describe("syncWorker", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("executeAction", () => {
+    it("executes TIP_INTENT action successfully", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+      const action: offlineStorage.QueuedAction = {
+        id: "act-1",
+        type: "TIP_INTENT",
+        payload: { creatorId: "alice", amount: "10" },
+        createdAt: Date.now(),
+        attempts: 0,
+        status: "pending",
+      };
+
+      await expect(executeAction(action, "https://api.example.com")).resolves.toBeUndefined();
+      expect(mockFetch).toHaveBeenCalledWith("https://api.example.com/tips/intents", expect.objectContaining({
+        method: "POST",
+      }));
+    });
+
+    it("throws when HTTP response is not ok", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+      const action: offlineStorage.QueuedAction = {
+        id: "act-2",
+        type: "POST_COMMENT",
+        payload: { creatorUsername: "alice", body: "Great stream!" },
+        createdAt: Date.now(),
+        attempts: 0,
+        status: "pending",
+      };
+
+      await expect(executeAction(action, "https://api.example.com")).rejects.toThrowError("HTTP 500");
+    });
+  });
+
+  describe("runSync", () => {
+    it("syncs all pending actions and emits completion events", async () => {
+      mockFetch.mockResolvedValue({ ok: true });
+
+      const action: offlineStorage.QueuedAction = {
+        id: "act-1",
+        type: "TIP_INTENT",
+        payload: { creatorId: "alice" },
+        createdAt: Date.now(),
+        attempts: 0,
+        status: "pending",
+      };
+
+      vi.spyOn(offlineStorage, "getPendingActions").mockResolvedValue([action]);
+      vi.spyOn(offlineStorage, "updateAction").mockResolvedValue();
+      vi.spyOn(offlineStorage, "removeAction").mockResolvedValue();
+
+      const messages: any[] = [];
+      const result = await runSync("https://api.example.com", undefined, (msg) => messages.push(msg));
+
+      expect(result.synced).toBe(1);
+      expect(result.failed).toBe(0);
+      expect(messages).toEqual([
+        { type: "SYNC_STARTED" },
+        { type: "ACTION_SUCCESS", id: "act-1" },
+        { type: "SYNC_COMPLETE", synced: 1, failed: 0 },
+      ]);
+    });
+
+    it("handles max-attempts failure and transitions status to failed", async () => {
+      mockFetch.mockRejectedValue(new Error("Network offline"));
+
+      const action: offlineStorage.QueuedAction = {
+        id: "act-fail",
+        type: "TOGGLE_REACTION",
+        payload: { commentId: "c1", emoji: "🔥" },
+        createdAt: Date.now(),
+        attempts: MAX_ATTEMPTS - 1, // Will reach MAX_ATTEMPTS
+        status: "pending",
+      };
+
+      vi.spyOn(offlineStorage, "getPendingActions").mockResolvedValue([action]);
+      const updateSpy = vi.spyOn(offlineStorage, "updateAction").mockResolvedValue();
+      vi.spyOn(offlineStorage, "removeAction").mockResolvedValue();
+
+      const messages: any[] = [];
+      const result = await runSync("https://api.example.com", undefined, (msg) => messages.push(msg));
+
+      expect(result.synced).toBe(0);
+      expect(result.failed).toBe(1);
+      expect(updateSpy).toHaveBeenCalledWith("act-fail", expect.objectContaining({
+        status: "failed",
+        attempts: MAX_ATTEMPTS,
+      }));
+      expect(messages).toContainEqual({
+        type: "ACTION_FAILED",
+        id: "act-fail",
+        error: "Network offline",
+      });
+    });
+
+    it("respects abort signal to cleanly halt processing", async () => {
+      mockFetch.mockResolvedValue({ ok: true });
+
+      const actions: offlineStorage.QueuedAction[] = [
+        {
+          id: "act-1",
+          type: "TIP_INTENT",
+          payload: {},
+          createdAt: Date.now(),
+          attempts: 0,
+          status: "pending",
+        },
+        {
+          id: "act-2",
+          type: "TIP_INTENT",
+          payload: {},
+          createdAt: Date.now(),
+          attempts: 0,
+          status: "pending",
+        },
+      ];
+
+      vi.spyOn(offlineStorage, "getPendingActions").mockResolvedValue(actions);
+      vi.spyOn(offlineStorage, "updateAction").mockResolvedValue();
+      vi.spyOn(offlineStorage, "removeAction").mockResolvedValue();
+
+      const controller = new AbortController();
+      controller.abort();
+
+      const result = await runSync("https://api.example.com", controller.signal, () => {});
+      expect(result.synced).toBe(0);
+    });
+  });
+});

--- a/src/workers/syncWorker.ts
+++ b/src/workers/syncWorker.ts
@@ -22,11 +22,12 @@ import {
   type QueuedAction,
 } from "@/utils/offlineStorage";
 
-const MAX_ATTEMPTS = 3;
+export const MAX_ATTEMPTS = 3;
 
-async function executeAction(
+export async function executeAction(
   action: QueuedAction,
   apiBase: string,
+  signal?: AbortSignal,
 ): Promise<void> {
   switch (action.type) {
     case "TIP_INTENT": {
@@ -34,6 +35,7 @@ async function executeAction(
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(action.payload),
+        signal,
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       break;
@@ -49,6 +51,7 @@ async function executeAction(
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
+        signal,
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       break;
@@ -60,6 +63,7 @@ async function executeAction(
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ emoji }),
+        signal,
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       break;
@@ -70,29 +74,40 @@ async function executeAction(
   }
 }
 
-async function runSync(apiBase: string): Promise<void> {
-  self.postMessage({ type: "SYNC_STARTED" });
+export async function runSync(
+  apiBase: string,
+  signal?: AbortSignal,
+  postMessageFn: (msg: unknown) => void = (msg) => self.postMessage(msg),
+): Promise<{ synced: number; failed: number }> {
+  postMessageFn({ type: "SYNC_STARTED" });
 
   const actions = await getPendingActions();
   let synced = 0;
   let failed = 0;
 
   for (const action of actions) {
+    if (signal?.aborted) break;
+
     await updateAction(action.id, { status: "syncing" });
 
     try {
-      await executeAction(action, apiBase);
+      await executeAction(action, apiBase, signal);
       await removeAction(action.id);
       synced++;
-      self.postMessage({ type: "ACTION_SUCCESS", id: action.id });
+      postMessageFn({ type: "ACTION_SUCCESS", id: action.id });
     } catch (err) {
+      if (signal?.aborted) {
+        await updateAction(action.id, { status: "pending" });
+        break;
+      }
+
       const attempts = action.attempts + 1;
       const error = err instanceof Error ? err.message : String(err);
 
       if (attempts >= MAX_ATTEMPTS) {
         await updateAction(action.id, { status: "failed", attempts, error });
         failed++;
-        self.postMessage({ type: "ACTION_FAILED", id: action.id, error });
+        postMessageFn({ type: "ACTION_FAILED", id: action.id, error });
       } else {
         // Back to pending for next sync cycle
         await updateAction(action.id, { status: "pending", attempts, error });
@@ -100,20 +115,37 @@ async function runSync(apiBase: string): Promise<void> {
     }
   }
 
-  self.postMessage({ type: "SYNC_COMPLETE", synced, failed });
+  postMessageFn({ type: "SYNC_COMPLETE", synced, failed });
+  return { synced, failed };
 }
 
-self.addEventListener("message", async (e: MessageEvent) => {
-  const { type, apiBase } = e.data as { type: string; apiBase?: string };
+let activeAbortController: AbortController | null = null;
 
-  if (type === "START_SYNC" && apiBase) {
-    try {
-      await runSync(apiBase);
-    } catch (err) {
-      self.postMessage({
-        type: "ERROR",
-        message: err instanceof Error ? err.message : "Sync failed",
-      });
+if (typeof self !== "undefined" && "addEventListener" in self) {
+  self.addEventListener("message", async (e: MessageEvent) => {
+    const { type, apiBase } = e.data as { type: string; apiBase?: string };
+
+    if (type === "STOP") {
+      if (activeAbortController) {
+        activeAbortController.abort();
+        activeAbortController = null;
+      }
+      return;
     }
-  }
-});
+
+    if (type === "START_SYNC" && apiBase) {
+      try {
+        activeAbortController = new AbortController();
+        await runSync(apiBase, activeAbortController.signal);
+      } catch (err) {
+        self.postMessage({
+          type: "ERROR",
+          message: err instanceof Error ? err.message : "Sync failed",
+        });
+      } finally {
+        activeAbortController = null;
+      }
+    }
+  });
+}
+


### PR DESCRIPTION
Closes #592

### Summary of Changes
1. **AbortSignal & STOP Message Support**: Refactored \src/workers/syncWorker.ts\ with \AbortController\ integration, allowing in-flight HTTP requests and queue loops to halt immediately upon receiving a \{ type: \"STOP\" }\ message.
2. **Modular Worker Functions**: Exported \executeAction\ and \unSync\ with customizable event dispatchers (\postMessageFn\) to enable direct unit testing outside dedicated Web Worker worker-threads.
3. **Automated Unit Tests**: Added unit tests in \src/workers/__tests__/syncWorker.test.ts\ verifying payload execution across all action types (\TIP_INTENT\, \POST_COMMENT\, \TOGGLE_REACTION\), retry limits (\MAX_ATTEMPTS = 3\), and graceful abort signal cancellation.

### Verification
- Executed Vitest test suite for \syncWorker.test.ts\:
  \\\ash
  npx vitest run src/workers/__tests__/syncWorker.test.ts
  # 1 passed (1), 5 tests passed (5/5, 100%)
  \\\
- Verified clean TypeScript compilation with \
px tsc --noEmit\.
