### PR TITLE
fix(i18n): unify locale configuration single source of truth with routing and add parity test suite

### DIFF
--- a/src/i18n/__tests__/i18nConfigParity.test.ts
+++ b/src/i18n/__tests__/i18nConfigParity.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { routing } from "../routing";
+import { locales, defaultLocale, localeNames, isRTL } from "../config";
+import fs from "fs";
+import path from "path";
+
+describe("i18n Configuration Single Source of Truth", () => {
+  it("synchronizes locales directly with routing.locales", () => {
+    expect(locales).toEqual(routing.locales);
+    expect(locales).toEqual(["en", "es", "fr", "zh", "ar"]);
+  });
+
+  it("sets defaultLocale to English (en)", () => {
+    expect(defaultLocale).toBe("en");
+    expect(routing.defaultLocale).toBe("en");
+  });
+
+  it("contains display names for every active locale", () => {
+    for (const loc of locales) {
+      expect(localeNames[loc]).toBeDefined();
+      expect(typeof localeNames[loc]).toBe("string");
+    }
+  });
+
+  it("correctly identifies RTL for Arabic and LTR for others", () => {
+    expect(isRTL("ar")).toBe(true);
+    expect(isRTL("en")).toBe(false);
+    expect(isRTL("es")).toBe(false);
+    expect(isRTL("fr")).toBe(false);
+    expect(isRTL("zh")).toBe(false);
+  });
+
+  it("confirms JSON message catalogs exist for every configured locale", () => {
+    const messagesDir = path.join(process.cwd(), "messages");
+    for (const loc of locales) {
+      const filePath = path.join(messagesDir, `${loc}.json`);
+      expect(fs.existsSync(filePath)).toBe(true);
+    }
+  });
+});

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,15 +1,17 @@
-export const locales = ['en', 'es', 'fr', 'de', 'ar', 'zh'] as const;
+import { routing } from './routing';
+
+export const locales = routing.locales;
 export type Locale = (typeof locales)[number];
 
-export const defaultLocale: Locale = 'en';
+export const defaultLocale: Locale = routing.defaultLocale as Locale;
 
 export const localeNames: Record<Locale, string> = {
   en: 'English',
   es: 'Español',
   fr: 'Français',
-  de: 'Deutsch',
-  ar: 'العربية',
   zh: '中文',
+  ar: 'العربية',
 };
 
-export const isRTL = (locale: Locale) => locale === 'ar';
+export const isRTL = (locale: Locale | string) => locale === 'ar';
+

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,6 +1,1 @@
-import { getRequestConfig } from 'next-intl/server';
-
-export default getRequestConfig(async ({ locale }) => ({
-  locale: locale ?? "en",
-  messages: (await import(`../../messages/${locale ?? "en"}.json`)).default
-}));
+export { default } from '../i18n';


### PR DESCRIPTION
Closes #591

### Summary of Changes
1. **Single Source of Truth for i18n Locales**: Refactored \src/i18n/config.ts\ to derive its locale list directly from \src/i18n/routing.ts\ (\outing.locales\), eliminating the stale German (\de\) locale entry that had no corresponding JSON message catalog or route support.
2. **Reconciled Request Config**: Aligned \src/i18n/request.ts\ to re-export the active root \src/i18n.ts\ configuration used by \
ext-intl/plugin\.
3. **Automated Parity Unit Tests**: Added unit tests in \src/i18n/__tests__/i18nConfigParity.test.ts\ verifying that \locales\, \outing.locales\, \defaultLocale\, \localeNames\, \isRTL\, and disk message catalogs remain in 100% parity across the active 5 locales (\en\, \es\, \r\, \zh\, \r\).

### Verification
- Executed Vitest test suite for \i18nConfigParity.test.ts\:
  \\\ash
  npx vitest run src/i18n/__tests__/i18nConfigParity.test.ts
  # 1 passed (1), 5 tests passed (5/5, 100%)
  \\\
- Verified clean TypeScript compilation with \
px tsc --noEmit\.
