### PR TITLE
feat(storage): add batch legacy migration, key enumeration, and namespace test suite

### DIFF
--- a/src/lib/__tests__/storageNamespaces.test.ts
+++ b/src/lib/__tests__/storageNamespaces.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  createNamespacedStorage,
+  createZustandStorage,
+  migrateLegacyKeys,
+  getAllNamespacedKeys,
+  clearAllNamespaced,
+} from "../storage";
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+
+  get length(): number {
+    return this.store.size;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+}
+
+describe("Namespaced Storage & Legacy Migration", () => {
+  let local: MemoryStorage;
+  let session: MemoryStorage;
+
+  beforeEach(() => {
+    local = new MemoryStorage();
+    session = new MemoryStorage();
+    Object.defineProperty(window, "localStorage", { value: local, writable: true, configurable: true });
+    Object.defineProperty(window, "sessionStorage", { value: session, writable: true, configurable: true });
+  });
+
+  it("prefixes keys with stj:domain: to isolate data across modules", () => {
+    const userStore = createNamespacedStorage("user");
+    const tipStore = createNamespacedStorage("tips");
+
+    userStore.setString("theme", "dark");
+    tipStore.setString("theme", "retro");
+
+    expect(localStorage.getItem("stj:user:theme")).toContain("dark");
+    expect(localStorage.getItem("stj:tips:theme")).toContain("retro");
+    expect(userStore.getString("theme")).toBe("dark");
+    expect(tipStore.getString("theme")).toBe("retro");
+  });
+
+  it("migrates legacy unnamespaced keys on read when legacyKey is provided", () => {
+    localStorage.setItem("user-fiat-preference", "eur");
+
+    const currencyStore = createNamespacedStorage("currency");
+    const val = currencyStore.getString("currency", { legacyKey: "user-fiat-preference" });
+
+    expect(val).toBe("eur");
+    expect(localStorage.getItem("stj:currency:currency")).toContain("eur");
+    // Old unnamespaced key is cleaned up to prevent duplicate drift
+    expect(localStorage.getItem("user-fiat-preference")).toBeNull();
+  });
+
+  it("migrates multiple legacy keys in batch via migrateLegacyKeys", () => {
+    localStorage.setItem("old_draft_key", "draft content");
+    localStorage.setItem("old_wallet_network", "testnet");
+
+    const migratedCount = migrateLegacyKeys([
+      { legacyKey: "old_draft_key", domain: "drafts", newKey: "current" },
+      { legacyKey: "old_wallet_network", domain: "wallet", newKey: "network" },
+      { legacyKey: "nonexistent_key", domain: "misc", newKey: "val" },
+    ]);
+
+    expect(migratedCount).toBe(2);
+    expect(localStorage.getItem("old_draft_key")).toBeNull();
+    expect(localStorage.getItem("stj:drafts:current")).toBe("draft content");
+    expect(localStorage.getItem("stj:wallet:network")).toBe("testnet");
+  });
+
+  it("enumerates only matching namespaced keys using getAllNamespacedKeys", () => {
+    const s1 = createNamespacedStorage("mod1");
+    const s2 = createNamespacedStorage("mod2");
+
+    s1.setString("k1", "v1");
+    s1.setString("k2", "v2");
+    s2.setString("k3", "v3");
+
+    const allMod1Keys = getAllNamespacedKeys("mod1");
+    expect(allMod1Keys).toEqual(["stj:mod1:k1", "stj:mod1:k2"]);
+
+    const allKeys = getAllNamespacedKeys();
+    expect(allKeys).toHaveLength(3);
+  });
+
+  it("clears all stj:* keys without wiping third-party keys", () => {
+    localStorage.setItem("third_party_key", "keep_me");
+    const s = createNamespacedStorage("auth");
+    s.setString("token", "xyz");
+
+    clearAllNamespaced("local");
+
+    expect(localStorage.getItem("stj:auth:token")).toBeNull();
+    expect(localStorage.getItem("third_party_key")).toBe("keep_me");
+  });
+});

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -290,3 +290,69 @@ export function clearAllNamespaced(
     /* ignore */
   }
 }
+
+// ─── Legacy Migration Utility ────────────────────────────────────────────────
+
+export interface LegacyMapping {
+  legacyKey: string;
+  domain: string;
+  newKey: string;
+  type?: "local" | "session";
+}
+
+/**
+ * Migrates multiple legacy unnamespaced keys in batch into their namespaced destinations.
+ * Safe to run on every startup; will only read/write if the legacy key exists and new key is unset.
+ */
+export function migrateLegacyKeys(mappings: LegacyMapping[]): number {
+  if (isServer()) return 0;
+  let count = 0;
+
+  for (const { legacyKey, domain, newKey, type = "local" } of mappings) {
+    const backend = getBackend(type);
+    if (!backend) continue;
+
+    try {
+      const nk = nsKey(domain, newKey);
+      const existing = backend.getItem(nk);
+      if (existing === null) {
+        const legacy = backend.getItem(legacyKey);
+        if (legacy !== null) {
+          backend.setItem(nk, legacy);
+          backend.removeItem(legacyKey);
+          count++;
+        }
+      }
+    } catch {
+      /* ignore storage errors during migration */
+    }
+  }
+
+  return count;
+}
+
+// ─── Key Enumeration ─────────────────────────────────────────────────────────
+
+export function getAllNamespacedKeys(
+  domain?: string,
+  type: "local" | "session" = "local",
+): string[] {
+  const backend = getBackend(type);
+  if (!backend) return [];
+  const prefix = domain ? nsKey(domain, "") : PREFIX;
+  const result: string[] = [];
+
+  try {
+    for (let i = 0; i < backend.length; i++) {
+      const k = backend.key(i);
+      if (k && k.startsWith(prefix)) {
+        result.push(k);
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+
+  return result;
+}
+


### PR DESCRIPTION
Closes #577

### Summary of Changes
1. **Batch Legacy Storage Key Migration**: Added \migrateLegacyKeys(mappings)\ to \src/lib/storage.ts\ to batch-migrate legacy unnamespaced \localStorage\/\sessionStorage\ keys into isolated \stj:\:\\ namespaces upon startup without discarding returning users' preferences or draft state.
2. **Namespaced Key Enumeration**: Exported \getAllNamespacedKeys(domain?, type?)\ to safely inspect and manage active namespaced keys without interfering with foreign third-party storage items.
3. **Automated Unit Tests**: Added unit tests in \src/lib/__tests__/storageNamespaces.test.ts\ verifying prefix isolation across domains, automatic single-key migration on read, batch key migration, key enumeration, and targeted namespace clearing.

### Verification
- Executed Vitest test suite for \storageNamespaces.test.ts\:
  \\\ash
  npx vitest run src/lib/__tests__/storageNamespaces.test.ts
  # 1 passed (1), 5 tests passed (5/5, 100%)
  \\\
- Verified clean TypeScript compilation with \
px tsc --noEmit\.
