### PR TITLE
fix(stellar): wire StellarNetwork type into utility functions and re-…

### DIFF
--- a/src/__tests__/utils/stellar.test.ts
+++ b/src/__tests__/utils/stellar.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import {
+  getNetworkPassphrase,
+  formatAddress,
+  getBalance,
+  STELLAR_NETWORK,
+  STELLAR_HORIZON_URL,
+} from "@/utils/stellar";
+import { NETWORKS } from "@/lib/wallet";
+
+describe("stellar utility", () => {
+  it("exports STELLAR_NETWORK and STELLAR_HORIZON_URL", () => {
+    expect(STELLAR_NETWORK).toBeDefined();
+    expect(STELLAR_HORIZON_URL).toBeDefined();
+  });
+
+  it("returns passphrase for default network", () => {
+    const passphrase = getNetworkPassphrase();
+    expect(passphrase).toBe(NETWORKS[STELLAR_NETWORK].passphrase);
+  });
+
+  it("returns passphrase for explicit StellarNetwork", () => {
+    expect(getNetworkPassphrase("TESTNET")).toBe(NETWORKS["TESTNET"].passphrase);
+    expect(getNetworkPassphrase("PUBLIC")).toBe(NETWORKS["PUBLIC"].passphrase);
+  });
+
+  it("formats Stellar address correctly", () => {
+    const addr = "GABC1234567890XYZWXYZ";
+    expect(formatAddress(addr)).toBe("GABC...WXYZ");
+    expect(formatAddress("")).toBe("");
+  });
+
+  it("getBalance returns account balance for default and explicit network", async () => {
+    const balance = await getBalance("GBAD_TEST_KEY");
+    expect(balance).toBe("0.0");
+
+    const testnetBalance = await getBalance("GBAD_TEST_KEY", "TESTNET");
+    expect(testnetBalance).toBe("0.0");
+  });
+});

--- a/src/utils/stellar.ts
+++ b/src/utils/stellar.ts
@@ -6,22 +6,33 @@ import {
   NETWORKS,
 } from "@/lib/wallet";
 
+export type { StellarNetwork };
+
 export const STELLAR_NETWORK = DEFAULT_NETWORK;
 export const STELLAR_HORIZON_URL = NETWORKS[STELLAR_NETWORK].horizonUrl;
 
 export const stellarServer = new Horizon.Server(STELLAR_HORIZON_URL);
 
-export const getNetworkPassphrase = () =>
-  NETWORKS[STELLAR_NETWORK].passphrase;
+export const getNetworkPassphrase = (
+  network: StellarNetwork = STELLAR_NETWORK
+) => NETWORKS[network].passphrase;
 
 export const formatAddress = (address: string) => {
   if (!address) return "";
   return `${address.slice(0, 4)}...${address.slice(-4)}`;
 };
 
-export const getBalance = async (publicKey: string) => {
+export const getBalance = async (
+  publicKey: string,
+  network: StellarNetwork = STELLAR_NETWORK
+) => {
   try {
-    const account = await stellarServer.loadAccount(publicKey);
+    const horizonUrl = NETWORKS[network].horizonUrl;
+    const server =
+      network === STELLAR_NETWORK
+        ? stellarServer
+        : new Horizon.Server(horizonUrl);
+    const account = await server.loadAccount(publicKey);
     const balance = account.balances.find((b) => b.asset_type === "native");
     return balance ? balance.balance : "0.0";
   } catch (error) {
@@ -29,3 +40,4 @@ export const getBalance = async (publicKey: string) => {
     return "0.0";
   }
 };
+


### PR DESCRIPTION
```markdown 
### Pull Request Description

Close #588 
---

#### Summary of the issue
ESLint flagged `@typescript-eslint/no-unused-vars` in `src/utils/stellar.ts` due to an unused `StellarNetwork` type import. Upon investigation, utility functions in `stellar.ts` (`getNetworkPassphrase` and `getBalance`) were missing type annotations and network parameter options, preventing callers from passing network options dynamically in a type-safe manner.
---
#### Root cause
`type StellarNetwork` was imported from `@/lib/wallet` into `src/utils/stellar.ts` but never attached to function parameters or re-exported, causing ESLint warnings while leaving network handling in `stellar.ts` tied solely to default network fallbacks.

#### Solution implemented
1. Re-exported `StellarNetwork` type from `src/utils/stellar.ts`.
2. Annotated `getNetworkPassphrase` parameter with `(network: StellarNetwork = STELLAR_NETWORK)` to allow type-safe network passphrase retrieval for any Stellar network (`"TESTNET"` | `"PUBLIC"`).
3. Annotated `getBalance` parameter with `(publicKey: string, network: StellarNetwork = STELLAR_NETWORK)` to dynamically query balances across any configured network.
4. Added comprehensive unit tests in `src/__tests__/utils/stellar.test.ts`.
---
#### Key changes made
- Modified `src/utils/stellar.ts`: Re-exported `StellarNetwork` and wired it into `getNetworkPassphrase` and `getBalance` parameters with default fallback.
- Added `src/__tests__/utils/stellar.test.ts`: Added unit tests covering default and custom network parameters for `stellar.ts` utility functions.
---
#### Any trade-offs or considerations
- Preserved default argument fallback (`network = STELLAR_NETWORK`) on both `getNetworkPassphrase` and `getBalance` to ensure zero breaking changes for existing consumers that call these functions without arguments.

#### Testing steps (how to verify the fix)
1. Run ESLint on the modified files: `npx eslint src/utils/stellar.ts src/__tests__/utils/stellar.test.ts` — confirm zero `@typescript-eslint/no-unused-vars` errors.
2. Run TypeScript typecheck: `npx tsc --noEmit` — confirm zero type errors.
3. Run unit tests: `npx vitest run src/__tests__/utils/stellar.test.ts` — verify all 5 test cases pass.
```
_Please kindly review this task. If there are any corrections, improvements, adjustments, or merge conflicts that you notice regarding my implementation, I'd really appreciate your feedback. I'd also love to hear your overall review of my work on this branch. Thank you!_