### PR TITLE
fix(tests): update TagCloud and TagBadge tests to match current component implementation (#569)

### DIFF
--- a/src/components/__tests__/TagBadge.test.tsx
+++ b/src/components/__tests__/TagBadge.test.tsx
@@ -9,6 +9,11 @@ Object.assign(navigator, {
   },
 });
 
+// Mock next-intl
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
 describe('TagBadge', () => {
   it('renders tag with default props', () => {
     render(<TagBadge tag="web3" />);
@@ -17,13 +22,13 @@ describe('TagBadge', () => {
 
   it('renders with different sizes', () => {
     const { rerender } = render(<TagBadge tag="nft" size="sm" />);
-    expect(screen.getByText('#nft')).toHaveClass('px-2', 'py-1', 'text-xs');
+    expect(screen.getByText('#nft')).toHaveClass('px-2 py-1 text-xs');
 
     rerender(<TagBadge tag="nft" size="md" />);
-    expect(screen.getByText('#nft')).toHaveClass('px-3', 'py-1.5', 'text-sm');
+    expect(screen.getByText('#nft')).toHaveClass('px-3 py-1.5 text-sm');
 
     rerender(<TagBadge tag="nft" size="lg" />);
-    expect(screen.getByText('#nft')).toHaveClass('px-4', 'py-2', 'text-base');
+    expect(screen.getByText('#nft')).toHaveClass('px-4 py-2 text-base');
   });
 
   it('handles click when clickable', () => {
@@ -52,14 +57,14 @@ describe('TagBadge', () => {
     fireEvent.mouseDown(element);
     
     // Should show checkmark icon after copy
-    await screen.findByRole('img', { hidden: true });
+    await screen.findByRole('img', { name: 'Copied' });
   });
 
   it('has proper accessibility attributes', () => {
     render(<TagBadge tag="defi" clickable />);
     
     const button = screen.getByRole('button');
-    expect(button).toHaveAttribute('aria-label', expect.stringContaining('defi'));
+    expect(button).toHaveAttribute('aria-label', 'Tag: defi, clickable');
     expect(button).toHaveAttribute('title', 'Copy tag: #defi');
   });
 

--- a/src/components/__tests__/TagCloud.test.tsx
+++ b/src/components/__tests__/TagCloud.test.tsx
@@ -2,6 +2,11 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { TagCloud } from '../TagCloud';
 
+// Mock next-intl
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
 const mockTags = [
   { tag: 'web3', count: 45 },
   { tag: 'nft', count: 38 },
@@ -14,16 +19,16 @@ describe('TagCloud', () => {
     render(<TagCloud tags={mockTags} />);
     
     expect(screen.getByText('Popular Tags')).toBeInTheDocument();
-    expect(screen.getByText(/#web3/)).toBeInTheDocument();
-    expect(screen.getByText(/#nft/)).toBeInTheDocument();
+    expect(screen.getByText('#web3')).toBeInTheDocument();
+    expect(screen.getByText('#nft')).toBeInTheDocument();
   });
 
   it('limits visible tags by maxVisible prop', () => {
     render(<TagCloud tags={mockTags} maxVisible={2} />);
     
-    expect(screen.getByText(/#web3/)).toBeInTheDocument();
-    expect(screen.getByText(/#nft/)).toBeInTheDocument();
-    expect(screen.queryByText(/#defi/)).not.toBeInTheDocument();
+    expect(screen.getByText('#web3')).toBeInTheDocument();
+    expect(screen.getByText('#nft')).toBeInTheDocument();
+    expect(screen.queryByText('#defi')).not.toBeInTheDocument();
     
     // Should show "Show all" button
     expect(screen.getByText('Show all 4')).toBeInTheDocument();
@@ -35,8 +40,8 @@ describe('TagCloud', () => {
     const showAllButton = screen.getByText('Show all 4');
     fireEvent.click(showAllButton);
     
-    expect(screen.getByText(/#defi/)).toBeInTheDocument();
-    expect(screen.getByText(/#dao/)).toBeInTheDocument();
+    expect(screen.getByText('#defi')).toBeInTheDocument();
+    expect(screen.getByText('#dao')).toBeInTheDocument();
     expect(screen.getByText('Show less')).toBeInTheDocument();
   });
 
@@ -44,7 +49,7 @@ describe('TagCloud', () => {
     const onTagClick = vi.fn();
     render(<TagCloud tags={mockTags} onTagClick={onTagClick} />);
     
-    const web3Tag = screen.getByText(/#web3/);
+    const web3Tag = screen.getByText('#web3');
     fireEvent.click(web3Tag);
     
     expect(onTagClick).toHaveBeenCalledWith('web3');


### PR DESCRIPTION
## Overview
This PR fixes failing tests in TagCloud.test.tsx (4 failures) and TagBadge.test.tsx (1 failure) by updating them to match the current component implementations. The tests had fallen out of sync with component changes - TagCloud now renders inline div elements instead of using TagBadge components, and accessibility attributes/CSS classes had changed in TagBadge.

## Related Issue
Closes [#569](https://github.com/Bonizozo/stellar-tipjar-frontend/issues/569)