### PR TITLE
docs(config): update locale comment to match actual configuration

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,7 +9,7 @@ const withBundleAnalyzer = createBundleAnalyzer({
 });
 
 // i18n is handled via next-intl with locale routing
-// Supported locales: en, es, fr, zh, ar, he — preference persisted in localStorage
+// Supported locales: en, es, fr, zh, ar — preference persisted in localStorage
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   typedRoutes: true,


### PR DESCRIPTION
## Overview
This PR fixes stale documentation in next.config.ts that incorrectly listed Hebrew (he) as a supported locale. The comment has been updated to match the actual configuration.

## Related Issue
Closes #590

## Changes
- [MODIFY] next.config.ts
  - Updated comment to remove non-existent Hebrew (he) locale
  - Comment now correctly lists 5 supported locales: en, es, fr, zh, ar
  - Matches actual routing configuration in src/i18n/routing.ts
  - Matches available message files in messages/ directory