### PR TITLE
fix(stories): resolve rules-of-hooks violation in CustomVideoPlayer story

### DIFF
--- a/src/stories/CustomVideoPlayer.stories.tsx
+++ b/src/stories/CustomVideoPlayer.stories.tsx
@@ -111,41 +111,43 @@ export const AutoPlay: Story = {
   },
 };
 
-export const Interactive: Story = {
-  render: () => {
-    const [tips, setTips] = useState<TimestampTip[]>(demoTips);
+function InteractiveStory() {
+  const [tips, setTips] = useState<TimestampTip[]>(demoTips);
 
-    const handleTipSubmit = async (
-      amount: string,
-      message: string,
-      timestamp: number
-    ) => {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      
-      const newTip: TimestampTip = {
-        id: Date.now().toString(),
-        timestamp,
-        amount,
-        message,
-        username: 'you',
-        createdAt: new Date().toISOString(),
-      };
+  const handleTipSubmit = async (
+    amount: string,
+    message: string,
+    timestamp: number
+  ) => {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
 
-      setTips([...tips, newTip]);
+    const newTip: TimestampTip = {
+      id: Date.now().toString(),
+      timestamp,
+      amount,
+      message,
+      username: 'you',
+      createdAt: new Date().toISOString(),
     };
 
-    return (
-      <div className="p-8 bg-gray-50 dark:bg-gray-900 min-h-screen">
-        <CustomVideoPlayer
-          src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
-          poster="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg"
-          chapters={demoChapters}
-          qualities={demoQualities}
-          timestampTips={tips}
-          creatorUsername="demo_creator"
-          onTipSubmit={handleTipSubmit}
-        />
-      </div>
-    );
-  },
+    setTips([...tips, newTip]);
+  };
+
+  return (
+    <div className="p-8 bg-gray-50 dark:bg-gray-900 min-h-screen">
+      <CustomVideoPlayer
+        src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+        poster="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg"
+        chapters={demoChapters}
+        qualities={demoQualities}
+        timestampTips={tips}
+        creatorUsername="demo_creator"
+        onTipSubmit={handleTipSubmit}
+      />
+    </div>
+  );
+}
+
+export const Interactive: Story = {
+  render: () => <InteractiveStory />,
 };


### PR DESCRIPTION
## Overview

This PR fixes the `react-hooks/rules-of-hooks` violation flagged in [#565](https://github.com/Bonizozo/stellar-tipjar-frontend/issues/565): `stories/CustomVideoPlayer.stories.tsx` called `useState` inside the `Interactive` story's `render` function, which ESLint's hook-name heuristics don't recognize as a valid React component — a shape that only works by accident in Storybook and risks state attaching to the wrong component instance across re-renders.

## Related Issue

Closes [#565](https://github.com/Bonizozo/stellar-tipjar-frontend/issues/565)

## Changes

- **\[MODIFY\]** `src/stories/CustomVideoPlayer.stories.tsx`
  - Extracted the stateful story body out of the `Interactive` story's `render` function into a properly-named `InteractiveStory` component (uppercase name), so `useState` and the tip-submit handler live in a real React component.
  - The `Interactive` story now delegates to `<InteractiveStory />`, preserving the exact same demo UI and behavior (adding timestamp tips).

## Verification Results

```
npx eslint src/stories/CustomVideoPlayer.stories.tsx
✅ 0 problems (0 errors, 0 warnings) — previously 1 react-hooks/rules-of-hooks warning

npx tsc --noEmit
✅ Passes
```

Confirming the lint rule is now satisfied legitimately (no `eslint-disable`), which also removes the runtime doubt about hook-ownership raised in the issue.

## Acceptance Criteria

| Acceptance Criteria | Status |
| --- | --- |
| `useState` no longer called inside a `render` function that isn't a component | ✅ Extracted into `InteractiveStory` component |
| `react-hooks/rules-of-hooks` warning resolved without a silently-ignored disable | ✅ `eslint` reports 0 problems on the file |
| Story delivers identical behavior for the Interactive story in Storybook | ✅ Story now renders `<InteractiveStory />` with the same props, state, and handlers |