### PR TITLE
feat: enforce bundle budget in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,3 +147,6 @@ jobs:
 
       - name: Build Next.js app
         run: npm run build
+
+      - name: Check bundle budget
+        run: npm run check:bundle-budget


### PR DESCRIPTION
# Enforce bundle-budget check in CI

## Summary

Wired the existing `scripts/check-bundle-budget.js` check into the production CI build job. Previously, the script existed and was exposed via `npm run check:bundle-budget`, but CI never executed it — so a bundle-size regression would pass CI unchecked.

## Change

`.github/workflows/ci.yml` — Added `npm run check:bundle-budget` as a step in the `build` job, immediately after `npm run build`. The check runs after the production build so that `.next/build-manifest.json` is available, and its non-zero exit status on budget violation will fail the CI job.

## Verification

- **Normal case:** Production build produced 168.1 KB gzip shared First Load JS (under the 190 KB budget) → check passed.
- **Regression case:** Simulated a budget violation by running the check with a reduced budget → the script exited with code 1 as expected.
- No `|| true`, `continue-on-error`, or other suppression patterns were used.

## What is NOT changed

- `scripts/check-bundle-budget.js` — untouched, existing logic is correct
- The 190 KB gzip budget — unchanged
- `package.json` — already had the `check:bundle-budget` script
- All other CI jobs and workflow behavior — untouched


Closes #604 