### PR TITLE
fix(i18n): guard against translation-catalog drift and complete locale catalogs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,24 @@ jobs:
       - name: Run ESLint
         run: npm run lint
 
+  i18n:
+    name: i18n Catalog Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Check translation-catalog coverage
+        run: npm run check:i18n
+
   typecheck:
     name: Typecheck (tsc --noEmit)
     runs-on: ubuntu-latest

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -15,13 +15,19 @@
     "confirm": "تأكيد"
   },
   "nav": {
+    "brandName": "Stellar Tip Jar",
     "home": "الرئيسية",
     "explore": "استكشاف المبدعين",
     "tips": "إرسال إكرامية",
     "about": "حول",
     "dashboard": "لوحة التحكم",
     "settings": "الإعدادات",
-    "profile": "الملف الشخصي"
+    "profile": "الملف الشخصي",
+    "searchPlaceholder": "ابحث عن المبدعين...",
+    "openMenu": "فتح القائمة",
+    "achievements": "الإنجازات",
+    "widgets": "الودجتس",
+    "marketplace": "السوق"
   },
   "wallet": {
     "connect": "ربط المحفظة",

--- a/messages/es.json
+++ b/messages/es.json
@@ -15,13 +15,19 @@
     "confirm": "Confirmar"
   },
   "nav": {
+    "brandName": "Stellar Tip Jar",
     "home": "Inicio",
     "explore": "Explorar Creadores",
     "tips": "Enviar una Propina",
     "about": "Acerca de",
     "dashboard": "Panel",
     "settings": "Configuración",
-    "profile": "Perfil"
+    "profile": "Perfil",
+    "searchPlaceholder": "Buscar creadores...",
+    "openMenu": "Abrir menú móvil",
+    "achievements": "Logros",
+    "widgets": "Widgets",
+    "marketplace": "Marketplace"
   },
   "wallet": {
     "connect": "Conectar Billetera",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -15,13 +15,19 @@
     "confirm": "Confirmer"
   },
   "nav": {
+    "brandName": "Stellar Tip Jar",
     "home": "Accueil",
     "explore": "Explorer les Créateurs",
     "tips": "Envoyer un Pourboire",
     "about": "À propos",
     "dashboard": "Tableau de bord",
     "settings": "Paramètres",
-    "profile": "Profil"
+    "profile": "Profil",
+    "searchPlaceholder": "Rechercher des créateurs...",
+    "openMenu": "Ouvrir le menu mobile",
+    "achievements": "Réalisations",
+    "widgets": "Widgets",
+    "marketplace": "Marketplace"
   },
   "wallet": {
     "connect": "Connecter le Portefeuille",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -15,13 +15,19 @@
     "confirm": "确认"
   },
   "nav": {
+    "brandName": "Stellar Tip Jar",
     "home": "首页",
     "explore": "探索创作者",
     "tips": "发送小费",
     "about": "关于",
     "dashboard": "仪表板",
     "settings": "设置",
-    "profile": "个人资料"
+    "profile": "个人资料",
+    "searchPlaceholder": "搜索创作者...",
+    "openMenu": "打开移动菜单",
+    "achievements": "成就",
+    "widgets": "小部件",
+    "marketplace": "市场"
   },
   "wallet": {
     "connect": "连接钱包",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "check:bundle-budget": "node scripts/check-bundle-budget.js",
+    "check:i18n": "node scripts/check-locale-catalogs.js",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report",

--- a/scripts/check-locale-catalogs.js
+++ b/scripts/check-locale-catalogs.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+/**
+ * Locale-catalog completeness check.
+ *
+ * next-intl falls back silently to the default locale (or to the raw key) for
+ * any message missing from a non-default catalog, so a genuinely incomplete
+ * `fr.json`/`ar.json`/etc. produces no error, warning, or test failure — just
+ * English text (or a `nav.explore`-style key) quietly appearing in the middle
+ * of an otherwise-localized page. Because `en` is complete by definition, a
+ * reviewer glancing at `en.json` never sees the gap.
+ *
+ * This script treats `messages/en.json` as the presumed-complete source of
+ * truth and diffs every other locale's key set against it, failing the check
+ * when any key is missing. The point is to catch translation-catalog drift
+ * mechanically rather than relying on someone browsing the app in each
+ * configured language.
+ *
+ * Usage:
+ *   node scripts/check-locale-catalogs.js              # fail on missing keys
+ *   node scripts/check-locale-catalogs.js --strict     # also fail on extra keys
+ *   node scripts/check-locale-catalogs.js --dir=<path> # audit a custom directory (testing)
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const DEFAULT_MESSAGES_DIR = path.join(process.cwd(), "messages");
+
+/**
+ * Flatten a nested catalog object into an array of dotted keys, e.g.
+ * { nav: { home: "Home" } } -> ["nav.home"]. Arrays are treated as leaves.
+ */
+function flattenKeys(obj, prefix = "", out = []) {
+  for (const [key, value] of Object.entries(obj)) {
+    const dotted = prefix ? `${prefix}.${key}` : key;
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      flattenKeys(value, dotted, out);
+    } else {
+      out.push(dotted);
+    }
+  }
+  return out;
+}
+
+/**
+ * Audit one locale catalog against the `en` source of truth.
+ * @param {object} source   parsed `en` catalog (the source of truth)
+ * @param {object} catalog  parsed locale catalog under audit
+ * @returns {{ missing: string[], extra: string[] }}
+ */
+function auditCatalog(source, catalog) {
+  const sourceKeys = flattenKeys(source).sort();
+  const catalogKeys = flattenKeys(catalog).sort();
+  const catalogSet = new Set(catalogKeys);
+
+  const missing = sourceKeys.filter((key) => !catalogSet.has(key));
+  const extra = catalogKeys.filter((key) => !sourceKeys.includes(key));
+  return { missing, extra };
+}
+
+/**
+ * Audit every non-`en` catalog in `messagesDir`.
+ * @returns {Array<{ locale: string, missing: string[], extra: string[] }>}
+ */
+function auditAllCatalogs(messagesDir) {
+  const files = fs
+    .readdirSync(messagesDir)
+    .filter((f) => f.endsWith(".json"))
+    .sort();
+
+  const sourcePath = path.join(messagesDir, "en.json");
+  if (!fs.existsSync(sourcePath)) {
+    throw new Error(
+      `[locale-catalogs] ${sourcePath} not found — the \`en\` catalog is the source of truth.`,
+    );
+  }
+
+  const source = JSON.parse(fs.readFileSync(sourcePath, "utf8"));
+
+  return files
+    .filter((f) => f !== "en.json")
+    .map((f) => {
+      const locale = f.replace(/\.json$/, "");
+      const catalog = JSON.parse(
+        fs.readFileSync(path.join(messagesDir, f), "utf8"),
+      );
+      const { missing, extra } = auditCatalog(source, catalog);
+      return { locale, missing, extra };
+    });
+}
+
+function parseDirArg() {
+  const arg = process.argv.find((a) => a.startsWith("--dir="));
+  if (!arg) return DEFAULT_MESSAGES_DIR;
+  const dir = arg.split("=")[1];
+  if (!fs.existsSync(dir)) {
+    throw new Error(`[locale-catalogs] Messages directory not found: ${dir}`);
+  }
+  return dir;
+}
+
+function main() {
+  const messagesDir = parseDirArg();
+  const strict = process.argv.includes("--strict");
+  const results = auditAllCatalogs(messagesDir);
+
+  const missingTotal = results.reduce((n, r) => n + r.missing.length, 0);
+  const extraTotal = results.reduce((n, r) => n + r.extra.length, 0);
+  const cleanCount = results.filter(
+    (r) => r.missing.length === 0 && r.extra.length === 0,
+  ).length;
+
+  console.log(`[locale-catalogs] Auditing catalogs against \`en\` in ${messagesDir}\n`);
+
+  for (const { locale, missing, extra } of results) {
+    if (missing.length === 0 && extra.length === 0) {
+      continue;
+    }
+
+    console.log(`  ${locale}:`);
+    for (const key of missing) {
+      console.log(`    MISSING  ${key}`);
+    }
+    for (const key of extra) {
+      console.log(`    EXTRA    ${key}`);
+    }
+  }
+
+  console.log(
+    `\n  ${cleanCount}/${results.length} non-en catalogs have the exact same key set as \`en\`.`,
+  );
+
+  const strictFailure = strict && extraTotal > 0;
+  if (missingTotal > 0 || strictFailure) {
+    const reasons = [];
+    if (missingTotal > 0) {
+      reasons.push(`${missingTotal} key(s) missing from non-\`en\` catalogs`);
+    }
+    if (strictFailure) {
+      reasons.push(`${extraTotal} orphaned key(s) present (--strict)`);
+    }
+    console.error(
+      `\n[locale-catalogs] FAIL — ${reasons.join("; ")}.` +
+        "\nnext-intl silently falls back to `en` (or the raw key) for missing translations," +
+        "\nso incomplete catalogs are invisible without a mechanical check. Add the missing" +
+        "\nkeys to the affected catalog(s) or align the extra keys with `en`.",
+    );
+    process.exit(1);
+  }
+
+  if (extraTotal > 0) {
+    console.warn(
+      `\n[locale-catalogs] WARN — ${extraTotal} key(s) exist outside \`en\` (orphaned/never used). ` +
+        `Run with --strict to fail on these.`,
+    );
+  }
+
+  console.log("\n[locale-catalogs] PASS — every locale covers all `en` keys.");
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { flattenKeys, auditCatalog, auditAllCatalogs, main };

--- a/scripts/check-locale-catalogs.test.js
+++ b/scripts/check-locale-catalogs.test.js
@@ -1,0 +1,173 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+const { flattenKeys, auditCatalog, auditAllCatalogs } = require("./check-locale-catalogs");
+
+const SCRIPT = path.join(__dirname, "check-locale-catalogs.js");
+
+const MESSAGES_DIR = path.join(__dirname, "..", "messages");
+
+describe("check-locale-catalogs", () => {
+  describe("flattenKeys", () => {
+    it("flattens a nested catalog into dotted keys", () => {
+      const catalog = { nav: { home: "Home", sub: { x: "X" } }, common: { welcome: "Hi" } };
+      expect(flattenKeys(catalog).sort()).toEqual([
+        "common.welcome",
+        "nav.home",
+        "nav.sub.x",
+      ]);
+    });
+
+    it("treats arrays as leaf values", () => {
+      expect(flattenKeys({ list: ["a", "b"] })).toEqual(["list"]);
+    });
+  });
+
+  describe("auditCatalog", () => {
+    const source = { common: { welcome: "Hi" }, nav: { home: "Home", about: "About" } };
+
+    it("finds keys present in the source but missing in the catalog", () => {
+      const catalog = { common: { welcome: "Salut" }, nav: { home: "Accueil" } };
+      const { missing, extra } = auditCatalog(source, catalog);
+      expect(missing).toEqual(["nav.about"]);
+      expect(extra).toEqual([]);
+    });
+
+    it("reports keys in the catalog that the source does not define", () => {
+      const catalog = {
+        common: { welcome: "Salut" },
+        nav: { home: "Accueil", about: "Ã€ propos", settings: "RÃ©glages" },
+      };
+      const { missing, extra } = auditCatalog(source, catalog);
+      expect(missing).toEqual([]);
+      expect(extra).toEqual(["nav.settings"]);
+    });
+  });
+
+  describe("auditAllCatalogs (messages/)", () => {
+    let tmpDir;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "locale-catalogs-"));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("finds no missing keys in any of the shipped catalogs", () => {
+      const results = auditAllCatalogs(MESSAGES_DIR);
+      expect(results).toHaveLength(4);
+      for (const { locale, missing } of results) {
+        expect(missing, `locale ${locale} is missing keys`).toEqual([]);
+      }
+    });
+
+    it("flags a locale whose key set has drifted from en", () => {
+      fs.copyFileSync(path.join(MESSAGES_DIR, "en.json"), path.join(tmpDir, "en.json"));
+      fs.copyFileSync(path.join(MESSAGES_DIR, "fr.json"), path.join(tmpDir, "fr.json"));
+
+      const frPath = path.join(tmpDir, "fr.json");
+      const fr = JSON.parse(fs.readFileSync(frPath, "utf8"));
+      delete fr.nav;
+      fs.writeFileSync(frPath, JSON.stringify(fr, null, 2));
+
+      const results = auditAllCatalogs(tmpDir);
+      const frResult = results.find((r) => r.locale === "fr");
+      expect(frResult).toBeDefined();
+      expect(frResult.missing).toEqual([
+        "nav.about",
+        "nav.achievements",
+        "nav.brandName",
+        "nav.dashboard",
+        "nav.explore",
+        "nav.home",
+        "nav.marketplace",
+        "nav.openMenu",
+        "nav.profile",
+        "nav.searchPlaceholder",
+        "nav.settings",
+        "nav.tips",
+        "nav.widgets",
+      ]);
+    });
+  });
+
+  describe("main (CLI)", () => {
+    function runCli(dir, extraArgs = []) {
+      const res = spawnSync(
+        process.execPath,
+        [SCRIPT, `--dir=${dir}`, ...extraArgs],
+        { encoding: "utf8" },
+      );
+      return { ...res, output: `${res.stdout}\n${res.stderr}` };
+    }
+
+    function copyCatalogs(tmpDir, overrides = {}) {
+      fs.copyFileSync(path.join(MESSAGES_DIR, "en.json"), path.join(tmpDir, "en.json"));
+      for (const [file, mutate] of Object.entries(overrides)) {
+        const src = path.join(MESSAGES_DIR, file);
+        const dest = path.join(tmpDir, file);
+        fs.copyFileSync(src, dest);
+        if (mutate) {
+          const catalog = JSON.parse(fs.readFileSync(dest, "utf8"));
+          mutate(catalog);
+          fs.writeFileSync(dest, JSON.stringify(catalog, null, 2));
+        }
+      }
+    }
+
+    it("exits 0 and reports PASS when every locale matches en", () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "locale-cli-"));
+      try {
+        copyCatalogs(tmpDir);
+        const res = runCli(tmpDir);
+        expect(res.status).toBe(0);
+        expect(res.output).toContain("PASS");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("exits 1 and reports the missing keys when a catalog drifts", () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "locale-cli-"));
+      try {
+        copyCatalogs(tmpDir, {
+          "fr.json": (catalog) => {
+            delete catalog.nav;
+          },
+        });
+        const res = runCli(tmpDir);
+        expect(res.status).toBe(1);
+        expect(res.output).toContain("MISSING  nav.brandName");
+        expect(res.output).toContain("FAIL");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("warns but exits 0 on orphaned keys, and fails with --strict", () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "locale-cli-"));
+      try {
+        copyCatalogs(tmpDir, {
+          "es.json": (catalog) => {
+            catalog.nav.orphan = "never used";
+          },
+        });
+
+        const warn = runCli(tmpDir);
+        expect(warn.status).toBe(0);
+        expect(warn.output).toContain("EXTRA    nav.orphan");
+        expect(warn.output).toContain("WARN");
+        expect(warn.output).toContain("PASS");
+
+        const strict = runCli(tmpDir, ["--strict"]);
+        expect(strict.status).toBe(1);
+        expect(strict.output).toContain("orphaned key(s) present (--strict)");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What & why

Fixes #581.

`next-intl` silently falls back to the default locale (or the raw key) for any message missing from a non-default catalog. A genuinely incomplete `fr.json`/`ar.json`/`es.json`/`zh.json` therefore produces **no error, no warning, and no test failure** — just English text (or a `nav.explore`-style key) quietly appearing in the middle of an otherwise-localized page. `en` is complete by definition, so a reviewer only looking at `en.json` never sees the gap.

This PR makes catalog drift impossible to miss mechanically:

- **`scripts/check-locale-catalogs.js`** (new) — diffs every non-`en` catalog's key set against `messages/en.json` (the presumed-complete source of truth):
  - **Fails** (exit 1) when any key is missing from any of the other four locales.
  - **Warns** on keys that exist outside `en` (orphaned/never-used); fails on those too with `--strict`.
  - Pure Node, mirrors the style of the existing `scripts/check-bundle-budget.js`.
- **`scripts/check-locale-catalogs.test.js`** (new) — unit tests for the flatten/diff logic plus end-to-end CLI tests asserting exit codes and output (PASS / FAIL / WARN / strict).
- **`.github/workflows/ci.yml`** — new `i18n` job runs `npm run check:i18n` on every PR/push to `main`.
- **`package.json`** — exposes the check as `npm run check:i18n`.
- **`messages/{ar,es,fr,zh}.json`** — completed the `nav.*` keys that were missing (`brandName`, `searchPlaceholder`, `openMenu`, `achievements`, `widgets`, `marketplace`) so every catalog is now in parity with `en`.

## Verification

- `node scripts/check-locale-catalogs.js` → PASS, exit 0 (all 4 non-en catalogs now match `en` exactly).
- Simulated drift → exit 1 with `MISSING nav.<key>` reported per locale; `--strict` fails on orphaned keys; non-strict warns and exits 0.
- `npx vitest run scripts/check-locale-catalogs.test.js` → 9/9 passing.
- `npx eslint scripts/check-locale-catalogs.js scripts/check-locale-catalogs.test.js` → 0 errors.

## Notes

- `en` remains the source of truth by design (per the issue's recommended approach), so adding a new key only ever requires updating `en.json` + the other catalogs — and CI now catches anyone who forgets.
- Extra keys are non-fatal by default to avoid blocking on pre-existing orphaned keys; `--strict` is available for anyone who wants a hard gate.

Closes #581
