### PR TITLE
feat: fix locale matcher

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Matcher patterns from src/middleware.ts — kept in sync manually.
+ * These mirror the `config.matcher` export so that changes to one
+ * must be reflected in the other.
+ */
+const MATCHER = [
+  '/',
+  '/(en|es|fr|zh|ar)/:path*',
+  '/((?!api|_next|_vercel|.*\\..*).*)',
+];
+
+/**
+ * Replicate how Next.js evaluates middleware matcher entries (logical OR).
+ */
+function matchesMatcher(pathname: string): boolean {
+  return MATCHER.some((pattern) => {
+    if (pattern === '/') {
+      return pathname === '/';
+    }
+    if (pattern === '/(en|es|fr|zh|ar)/:path*') {
+      return /^\/(en|es|fr|zh|ar)(\/.*)?$/.test(pathname);
+    }
+    if (pattern === '/((?!api|_next|_vercel|.*\\..*).*)') {
+      return /^\/((?!api|_next|_vercel|.*\..*).*)$/.test(pathname);
+    }
+    return false;
+  });
+}
+
+describe('middleware matcher', () => {
+  describe('root', () => {
+    it('matches /', () => {
+      expect(matchesMatcher('/')).toBe(true);
+    });
+  });
+
+  describe('locale-prefixed routes', () => {
+    const locales = ['en', 'es', 'fr', 'zh', 'ar'] as const;
+
+    it.each(locales)('matches /%s', (locale) => {
+      expect(matchesMatcher(`/${locale}`)).toBe(true);
+    });
+
+    it.each(locales)('matches /%s/explore', (locale) => {
+      expect(matchesMatcher(`/${locale}/explore`)).toBe(true);
+    });
+
+    it.each(locales)('matches /%s/creator/alice', (locale) => {
+      expect(matchesMatcher(`/${locale}/creator/alice`)).toBe(true);
+    });
+
+    it.each(locales)('matches /%s/dashboard/marketplace', (locale) => {
+      expect(matchesMatcher(`/${locale}/dashboard/marketplace`)).toBe(true);
+    });
+  });
+
+  describe('un-prefixed page routes', () => {
+    it('matches /explore', () => {
+      expect(matchesMatcher('/explore')).toBe(true);
+    });
+
+    it('matches /creator/alice', () => {
+      expect(matchesMatcher('/creator/alice')).toBe(true);
+    });
+
+    it('matches /creator/some-other-user', () => {
+      expect(matchesMatcher('/creator/some-other-user')).toBe(true);
+    });
+
+    it('matches /marketplace', () => {
+      expect(matchesMatcher('/marketplace')).toBe(true);
+    });
+
+    it('matches /dashboard/marketplace', () => {
+      expect(matchesMatcher('/dashboard/marketplace')).toBe(true);
+    });
+
+    it('matches /tips', () => {
+      expect(matchesMatcher('/tips')).toBe(true);
+    });
+
+    it('matches /settings/notifications', () => {
+      expect(matchesMatcher('/settings/notifications')).toBe(true);
+    });
+
+    it('matches /discover/category-name', () => {
+      expect(matchesMatcher('/discover/category-name')).toBe(true);
+    });
+
+    it('matches /mentorship/chat/some-id', () => {
+      expect(matchesMatcher('/mentorship/chat/some-id')).toBe(true);
+    });
+
+    it('matches /certification/courses/123', () => {
+      expect(matchesMatcher('/certification/courses/123')).toBe(true);
+    });
+
+    it('matches /store/username', () => {
+      expect(matchesMatcher('/store/username')).toBe(true);
+    });
+
+    it('matches /team/teamname', () => {
+      expect(matchesMatcher('/team/teamname')).toBe(true);
+    });
+  });
+
+  describe('API routes are excluded', () => {
+    it('does not match /api/foo', () => {
+      expect(matchesMatcher('/api/foo')).toBe(false);
+    });
+
+    it('does not match /api/marketplace/orders', () => {
+      expect(matchesMatcher('/api/marketplace/orders')).toBe(false);
+    });
+
+    it('does not match /api/marketplace/orders/123', () => {
+      expect(matchesMatcher('/api/marketplace/orders/123')).toBe(false);
+    });
+
+    it('does not match /api/tips/schedule', () => {
+      expect(matchesMatcher('/api/tips/schedule')).toBe(false);
+    });
+
+    it('does not match /api/tips/abc/comments', () => {
+      expect(matchesMatcher('/api/tips/abc/comments')).toBe(false);
+    });
+
+    it('does not match /api/notifications/preferences', () => {
+      expect(matchesMatcher('/api/notifications/preferences')).toBe(false);
+    });
+
+    it('does not match /api/moderation', () => {
+      expect(matchesMatcher('/api/moderation')).toBe(false);
+    });
+
+    it('does not match /api/creators/discover', () => {
+      expect(matchesMatcher('/api/creators/discover')).toBe(false);
+    });
+  });
+
+  describe('internal Next.js paths are excluded', () => {
+    it('does not match /_next/static/chunks/main.js', () => {
+      expect(matchesMatcher('/_next/static/chunks/main.js')).toBe(false);
+    });
+
+    it('does not match /_next/data/build-id/page.json', () => {
+      expect(matchesMatcher('/_next/data/build-id/page.json')).toBe(false);
+    });
+
+    it('does not match /_next/webpack-hmr', () => {
+      expect(matchesMatcher('/_next/webpack-hmr')).toBe(false);
+    });
+  });
+
+  describe('static assets are excluded', () => {
+    it('does not match /favicon.ico', () => {
+      expect(matchesMatcher('/favicon.ico')).toBe(false);
+    });
+
+    it('does not match /image.png', () => {
+      expect(matchesMatcher('/image.png')).toBe(false);
+    });
+
+    it('does not match /logo.svg', () => {
+      expect(matchesMatcher('/logo.svg')).toBe(false);
+    });
+
+    it('does not match /photo.jpg', () => {
+      expect(matchesMatcher('/photo.jpg')).toBe(false);
+    });
+
+    it('does not match /banner.webp', () => {
+      expect(matchesMatcher('/banner.webp')).toBe(false);
+    });
+
+    it('does not match /robots.txt', () => {
+      expect(matchesMatcher('/robots.txt')).toBe(false);
+    });
+
+    it('does not match /sitemap.xml', () => {
+      expect(matchesMatcher('/sitemap.xml')).toBe(false);
+    });
+
+    it('does not match /manifest.json', () => {
+      expect(matchesMatcher('/manifest.json')).toBe(false);
+    });
+  });
+
+  describe('Vercel internal paths are excluded', () => {
+    it('does not match /_vercel/insights/view', () => {
+      expect(matchesMatcher('/_vercel/insights/view')).toBe(false);
+    });
+
+    it('does not match /_vercel/speed-insights/view', () => {
+      expect(matchesMatcher('/_vercel/speed-insights/view')).toBe(false);
+    });
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,12 @@
 import createMiddleware from 'next-intl/middleware';
+import { routing } from './i18n/routing';
 
-export default createMiddleware({
-  locales: ['en', 'es', 'fr', 'zh', 'ar'],
-  defaultLocale: 'en',
-  localePrefix: 'as-needed'
-});
+export default createMiddleware(routing);
 
 export const config = {
-  matcher: ['/', '/(en|es|fr|zh|ar)/:path*']
+  matcher: [
+    '/',
+    '/(en|es|fr|zh|ar)/:path*',
+    '/((?!api|_next|_vercel|.*\\..*).*)'
+  ]
 };


### PR DESCRIPTION
# Fix `middleware.ts` locale route matcher to cover un-prefixed routes

## Problem

The existing middleware matcher was:

```ts
matcher: ['/', '/(en|es|fr|zh|ar)/:path*']
```

This only matched `/` and locale-prefixed routes (`/en/...`, `/es/...`, etc.). With `localePrefix: 'as-needed'`, the next-intl docs [explicitly require](https://next-intl.dev/docs/routing/middleware#matcher-no-prefix) that the matcher detects un-prefixed pathnames so the middleware can handle locale cookie setting and strip superfluous locale prefixes.

All ~60 page routes in this app (explore, creator, marketplace, dashboard, etc.) live un-prefixed under `app/` — only the homepage has an `app/[locale]/` counterpart. The old matcher left every one of those routes completely invisible to the middleware.

## Changes

### `src/middleware.ts`

- Added the catch-all pattern `/((?!api|_next|_vercel|.*\\..*).*)` to match all application routes while excluding API routes, internal Next.js paths, Vercel internals, and static assets.
- Replaced the inline middleware config with a reference to `routing` from `src/i18n/routing.ts` to eliminate duplication.

**New matcher:**

```ts
matcher: [
  '/',
  '/(en|es|fr|zh|ar)/:path*',
  '/((?!api|_next|_vercel|.*\\..*).*)'
]
```

### `src/__tests__/middleware.test.ts` (new)

Added 54 tests verifying the matcher covers:

| Category | Covered routes |
|---|---|
| Root | `/` |
| Locale-prefixed | `/en`, `/en/explore`, `/es/creator/alice`, etc. (all 5 locales) |
| Un-prefixed static | `/explore`, `/marketplace`, `/dashboard/marketplace`, `/tips`, etc. |
| Un-prefixed dynamic | `/creator/alice`, `/team/teamname`, `/store/username`, etc. |
| API (excluded) | `/api/marketplace/orders`, `/api/tips/schedule`, etc. |
| `/_next/` (excluded) | `/_next/static/chunks/main.js`, etc. |
| Static assets (excluded) | `/favicon.ico`, `/image.png`, `/robots.txt`, etc. |
| `/_vercel/` (excluded) | `/_vercel/insights/view`, etc. |

## Verification

- `npm run typecheck` — passes
- `npm run lint` — 0 errors (521 pre-existing warnings, none new)
- `npm run test` — all 54 new middleware tests pass; pre-existing test failures unchanged


Closes #576 