### PR TITLE
fix: eliminate no-explicit-any in src/services and src/store, enforce as error

### DIFF
--- a/docs/lint-burndown.md
+++ b/docs/lint-burndown.md
@@ -1,0 +1,43 @@
+# Lint burn-down plan
+
+Tracks progress on driving `@typescript-eslint/no-explicit-any` (and the wider
+lint warning count) to zero, directory by directory, instead of leaving the
+whole category as a single undifferentiated pile. See [#563](https://github.com/Bonizozo/stellar-tipjar-frontend/issues/563).
+
+## Why this order
+
+`any` disables the type checker exactly where a bad shape is most likely to
+slip through silently. The directories that move real request/response and
+persisted-state data — `src/services/` and `src/store/` — carry the highest
+risk per occurrence, so they are burned down and locked first. Presentational
+code, then tests/stories, follow: a wrong prop type is far more likely to be
+caught by a code reviewer or a snapshot than a wrong shape flowing through an
+API client.
+
+## Priority order
+
+1. **`src/services/`, `src/store/`** — core request/response handling and
+   persisted app state. **Enforced as `error`** via a scoped override in
+   [`eslint.config.mjs`](../eslint.config.mjs) (test files excluded for now).
+2. `src/hooks/`, `src/lib/`, `src/utils/`, `src/schemas/`, `src/i18n*` —
+   shared logic consumed by many components.
+3. `src/app/`, `src/components/` — presentational/UI code.
+4. `src/**/__tests__/**`, `**/*.test.ts(x)`, `src/stories/` — lowest risk;
+   cleaned up last.
+
+## Status
+
+Counts are occurrences of `@typescript-eslint/no-explicit-any` reported by
+`npm run lint`.
+
+| Phase | Scope | Status | Remaining `any` |
+| --- | --- | --- | --- |
+| 1 | `src/services/`, `src/store/` (non-test) | ✅ Done — enforced as `error` | 0 |
+| 2 | `src/hooks/`, `src/lib/`, `src/utils/`, `src/schemas/`, `src/i18n*` | Not started | 25 |
+| 3 | `src/app/`, `src/components/` | Not started | 74 |
+| 4 | Tests, `src/stories/` (incl. `src/services/`/`src/store/` test files) | Not started | 27 |
+
+Re-run `npm run lint` and update this table's counts whenever a phase is
+worked on. When a phase's count reaches 0, flip its scope to `"error"` in
+`eslint.config.mjs` (following the pattern of the phase 1 override) so it
+stays regression-free going forward.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,6 +44,20 @@ const eslintConfig = [
       ],
     },
   },
+  {
+    // `no-explicit-any` burn-down, phase 1 (see docs/lint-burndown.md).
+    // src/services/** and src/store/** own real request/response and persisted-state
+    // shapes, so an `any` there is the likeliest place for a bad shape to slip past the
+    // type checker silently. These directories are held to "error" so no new `any` can
+    // land in them while the rest of the codebase is still being cleaned up under "warn".
+    // Test files are excluded for now (lowest priority in the burn-down plan) and stay
+    // at the global "warn" level.
+    files: ["src/services/**/*.{ts,tsx}", "src/store/**/*.{ts,tsx}"],
+    ignores: ["**/*.test.ts", "**/*.test.tsx", "**/__tests__/**"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "error",
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -100,7 +100,7 @@ async function applyPathThrottle(path: string, throttleMs = DEFAULT_THROTTLE_MS)
   lastRequestByPath.set(path, Date.now());
 }
 
-import { enqueueAction } from "@/utils/offlineStorage";
+import { enqueueAction, type ActionType } from "@/utils/offlineStorage";
 
 async function executeFetch<T>(path: string, init?: RequestInit, throttleMs?: number): Promise<T> {
   await applyPathThrottle(path, throttleMs);
@@ -135,8 +135,8 @@ async function executeFetch<T>(path: string, init?: RequestInit, throttleMs?: nu
     if (typeof window !== "undefined" && !navigator.onLine && init?.method === "POST") {
       console.warn(`[API] Offline detected, enqueuing ${path}`);
       
-      let type: any = null;
-      let payload = init.body ? JSON.parse(init.body as string) : {};
+      let type: ActionType | null = null;
+      let payload: Record<string, unknown> = init.body ? JSON.parse(init.body as string) : {};
 
       if (path.includes("/tips/intents")) type = "TIP_INTENT";
       else if (path.includes("/comments") && path.includes("/reactions")) type = "TOGGLE_REACTION";
@@ -148,8 +148,8 @@ async function executeFetch<T>(path: string, init?: RequestInit, throttleMs?: nu
 
       if (type) {
         await enqueueAction(type, payload);
-        const err = new Error("OFFLINE_ENQUEUED");
-        (err as any).enqueued = true;
+        const err = new Error("OFFLINE_ENQUEUED") as Error & { enqueued: boolean };
+        err.enqueued = true;
         throw err;
       }
     }
@@ -210,10 +210,17 @@ import { generateAvatarUrl } from "@/utils/imageUtils";
 
 // Leaderboards use simplified types for the extension and PWA
 export type Period = '24h' | '7d' | '30d' | 'all';
+export interface LeaderboardEntryItem {
+  name: string;
+  metric: number;
+  change24h: number;
+  rank: number;
+  avatarUrl?: string;
+}
 export interface LeaderboardsResponse {
-  tippers: any[];
-  creators: any[];
-  biggest: any[];
+  tippers: LeaderboardEntryItem[];
+  creators: LeaderboardEntryItem[];
+  biggest: LeaderboardEntryItem[];
 }
 
 export async function getCreatorStats(username: string): Promise<CreatorStats> {

--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -261,9 +261,8 @@ export class TeamService {
       }
 
       const result = await response.json();
-      return (Array.isArray(result) ? result : result.teams || []).map((team: any) =>
-        teamProfileSchema.parse(team)
-      );
+      const teams: unknown[] = Array.isArray(result) ? result : result.teams || [];
+      return teams.map((team: unknown) => teamProfileSchema.parse(team));
     } catch (error) {
       console.error("Error listing user teams:", error);
       return [];

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -18,7 +18,11 @@ export interface Notification {
   timestamp: Date;
   read: boolean;
   link?: string;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
+}
+
+interface PersistedNotification extends Omit<Notification, "timestamp"> {
+  timestamp: string | Date;
 }
 
 interface NotificationStoreState {
@@ -141,12 +145,12 @@ export const useNotificationStore = create<NotificationStoreState>()(
           typeof persistedState === "object" &&
           "notifications" in persistedState
         ) {
-          const notifs = (persistedState as any).notifications.map(
-            (n: any) => ({
-              ...n,
-              timestamp: new Date(n.timestamp),
-            }),
-          );
+          const notifs = (
+            persistedState as { notifications: PersistedNotification[] }
+          ).notifications.map((n) => ({
+            ...n,
+            timestamp: new Date(n.timestamp),
+          }));
           return {
             ...currentState,
             notifications: notifs,


### PR DESCRIPTION
Closes #563.

## What changed

Phase 1 of the `no-explicit-any` burn-down: `src/services/` and `src/store/` are the highest-risk directories (real request/response and persisted-state shapes), so they go first.

- **`src/services/api.ts`**: offline-enqueue `type`/`payload` now use the existing `ActionType` / `Record<string, unknown>` types instead of `any`; the `OFFLINE_ENQUEUED` error's `enqueued` flag is typed instead of cast through `any`; `LeaderboardsResponse`'s `tippers`/`creators`/`biggest` arrays get a real `LeaderboardEntryItem` shape (matching what `getLeaderboards()` actually builds).
- **`src/services/teamService.ts`**: `listUserTeams()` maps over `unknown` (each element is validated by `teamProfileSchema.parse`) instead of `any`.
- **`src/store/notificationStore.ts`**: `metadata` is `Record<string, unknown>`; the persisted state read in the zustand `merge` callback is typed via a new `PersistedNotification` interface instead of double `any` casts.

That's all 9 non-test `any` occurrences in these two directories eliminated.

- **`eslint.config.mjs`**: adds a scoped override so `@typescript-eslint/no-explicit-any` is `"error"` (not `"warn"`) for `src/services/**` and `src/store/**` going forward — this is the "tracked, enforced" part of the burn-down, not just a one-off cleanup. Test files in those directories are excluded for now (lowest priority, see below).
- **`docs/lint-burndown.md`**: a visible, tracked burn-down plan — priority order for the remaining phases (`hooks/lib/utils/schemas/i18n` → `app/components` → tests/stories) with current `any` counts per phase, so progress has a metric instead of "274 in one undifferentiated pile."

## Why this order

`any` disables the type checker exactly where a wrong shape is most likely to slip through silently and only fail at runtime. `src/services/` and `src/store/` move real request/response and persisted app state, so they carry the highest risk per occurrence — locking them down first, and enforcing it via CI-visible lint `error`, prevents regressions while the rest of the codebase (521 warnings total) is cleaned up incrementally.

## Checks

- ✅ `npm run lint` — 0 errors, 512 warnings (down from 521; no new errors from the scoped override)
- ✅ `npm run typecheck` — clean
- ⚠️ `npm run test` / `npm run test:e2e` — **already failing on `main` before this PR**, unrelated to this change. I verified by stashing this diff and re-running the exact same unit test suite against `main` (`1cc58d4`): identical result, 14 failed / 37 passed test files, 32/519 tests failing (WalletConnector, TeamInvite, useTeam, etc. — none of the files touched here). The upstream CI Pipeline run on `main` shows the same: Lint/Typecheck/Build green, Unit/E2E red (https://github.com/Bonizozo/stellar-tipjar-frontend/actions/runs/32372215405). That's a separate, pre-existing issue this PR doesn't attempt to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)